### PR TITLE
Bug #11022: find superordinate object before constructor again

### DIFF
--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
@@ -20,12 +20,9 @@ from univention.management.console.log import MODULE
 import univention.config_registry
 import univention.admin.filter
 import univention.admin.modules
+import univention.admin.handlers
 import traceback
 import re
-import shutil
-import time
-import zlib
-import logging
 
 #logfile = "/var/log/univention/asteriskMusicPython.log"
 ucr = univention.config_registry.ConfigRegistry()
@@ -575,3 +572,68 @@ def reverseFieldsSave(self):
 			obj.info.setdefault(foreignField, []).append(self.dn)
 			obj.modify()
 
+
+class AsteriskBase(univention.admin.handlers.simpleLdap):
+
+	def __init__(self, co, lo, position, dn='', superordinate=None, attributes=None):
+		self.co = co
+		self.lo = lo
+		self.dn = dn
+		self.position = position
+		self.superordinate = superordinate
+		self.oldattr = attributes or {}
+		self.openSuperordinate()
+		super(AsteriskBase, self).__init__(co, lo, position, dn, self.superordinate, attributes)
+		self.open()  # for backwards compatibility
+
+	def _validate_superordinate(self):
+		try:
+			super(AsteriskBase, self)._validate_superordinate()
+		except univention.admin.uexceptions.insufficientInformation:
+			pass
+
+	def ready(self):
+		try:
+			return super(AsteriskBase, self).ready()
+		except univention.admin.uexceptions.insufficientInformation as exc:
+			# FIXME: UDM requires objects to be underneath of its superordinate, this is not the case in these modules
+			if 'position' in str(exc) and 'subtree' in str(exc):
+				return True
+			raise
+
+	def openSuperordinate(self):
+		"""Wird von __init__ (siehe oben) aufgerufen.
+		Falls das Superordinate-Object dieses Objects nicht bereits
+		bekannt ist (weil es als Argument an __init__ übergeben wurde),
+		versucht diese Funktion das Superordinate aus dem LDAP
+		auszulesen, zu öffnen, und in self.superordinate zu
+		referenzieren.
+
+		Diese Funktionalität erleichtert es extrem, untergeordnete
+		Objekte zu modifizieren und wird von den UMC-Modulen
+		(insbesondere dem Musikupload) oft genutzt. Die von
+		Univention definierten Module haben diese Funktion nicht.
+		(Um diese modifizieren zu können muss man also von Hand erst
+		das übergeordnete Objekt öffnen, und dann dieses beim
+		Aufruf von __init__ übergeben)"""
+		if self.superordinate:
+			return
+
+		serverdn = self.oldattr.get("ast4ucsSrvchildServer") or self.lo.getAttr(self.dn, "ast4ucsSrvchildServer")
+
+		univention.admin.modules.update()
+		servermod = univention.admin.modules.get(univention.admin.modules.superordinate_names(self.module)[0])
+		if self.position:
+			# FIXME: init requires self.position to be set, otherwise it crashes. There are some calls (e.g. if this object doesn't exists yet?) where position is None.
+			univention.admin.modules.init(self.lo, self.position, servermod)
+		if serverdn:
+			serverdn = serverdn[0]
+			self.superordinate = servermod.object(self.co, self.lo, self.position, serverdn)
+			self.superordinate.open()
+		else:
+			# there must only be one asterisk/server object, so we can use lookup here
+			try:
+				self.superordinate = servermod.lookup(self.co, self.lo, '')[0]
+				self.superordinate.open()
+			except IndexError:
+				pass

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/agiscript.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/agiscript.py
@@ -22,6 +22,8 @@ import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
 
+from univention.admin.handlers.asterisk import AsteriskBase
+
 module = "asterisk/agiscript"
 short_description = u"Asterisk4UCS-Management: AGI-Script"
 operations = ['add', 'edit', 'remove', 'search', 'move']
@@ -66,40 +68,8 @@ mapping.register("priority", "ast4ucsAgiscriptPriority",
 mapping.register("content", "ast4ucsAgiscriptContent",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
-
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
 
 	def getContent(self):
 		return self.get("content", "").decode("base64")

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/asterisk.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/asterisk.py
@@ -76,18 +76,15 @@ def superordinatecmp(x, y):
 		return 1
 	return cmp(x, y)
 
-wizardsuperordinates = sorted(modulesWithSuperordinates.keys(), cmp=superordinatecmp)
-wizardtypesforsuper = {}
-for key, value in modulesWithSuperordinates.items():
-	wizardtypesforsuper[key] = [x.module for x in value]
-
 options = {}
 layout = []
 property_descriptions = {}
 mapping = univention.admin.mapping.mapping()
 
+
 class object(univention.admin.handlers.simpleLdap):
 	module=module
+
 
 def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
 		unique=0, required=0, timeout=-1, sizelimit=0):
@@ -100,8 +97,13 @@ def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
 			continue
 		ret += module.lookup(co, lo, filter_s, base, superordinate,
 			scope, unique, required, timeout, sizelimit)
+	if not superordinate:
+		result = []
+		for superord in ret:
+			result.extend(lookup(co, lo, filter_s, base, superord, scope=scope, unique=unique, required=required, timeout=timeout, sizelimit=sizelimit))
+		ret.extend(result)
 	return ret
+
 
 def identify(dn, attr, canonical=0):
 	pass
-

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/conferenceRoom.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/conferenceRoom.py
@@ -22,6 +22,7 @@ import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
 from univention.admin import uexceptions
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/conferenceRoom"
 short_description = u"Asterisk4UCS-Management: Konferenzraum"
@@ -104,40 +105,8 @@ mapping.register("musicOnHold", "ast4ucsConfroomMusiconhold",
 mapping.register("quietMode", "ast4ucsConfroomQuietmode",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
-
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
 
 	def _ldap_pre_ready(self):
 		super(object, self)._ldap_pre_ready()

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/contact.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/contact.py
@@ -24,6 +24,7 @@ import univention.admin.handlers
 import univention.admin.syntax
 import univention.admin.uexceptions
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/contact"
 short_description = u"Asterisk4UCS-Management: Kontakt"
@@ -103,33 +104,29 @@ class noNameError(univention.admin.uexceptions.insufficientInformation):
 	message = (u"Eines der Felder Vorname, Nachname und Organisation "
 			u"muss ausgefüllt sein.")
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
 
 	def __init__(self, co, lo, position, dn='', superordinate=None,
 			attributes=[]):
+		self.co = co
+		self.lo = lo
+		self.dn = dn
+		self.position = position
+		self.superordinate = superordinate
+		self.oldattr = attributes or {}
+		self.openSuperordinate()
 		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
 			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
 
 	def openSuperordinate(self):
 		if self.superordinate:
 			return
 
-		self.open()
-		pbdn = self.oldattr.get("ast4ucsPbchildPhonebook")
+		pbdn = self.oldattr.get("ast4ucsPbchildPhonebook") or self.lo.getAttr(self.dn, "ast4ucsPbchildPhonebook")
 		if not pbdn:
 			return
-
-		if pbdn.__iter__:
-			pbdn = pbdn[0]
+		pbdn = pbdn[0]
 
 		univention.admin.modules.update()
 		pbmod = univention.admin.modules.get("asterisk/phoneBook")

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/fax.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/fax.py
@@ -21,6 +21,7 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/fax"
 short_description = u"Asterisk4UCS-Management: Fax"
@@ -76,41 +77,9 @@ mapping.register("hostname", "ast4ucsSipclientHostname",
 mapping.register("password", "ast4ucsSipclientSecret",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
 
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
-	
 	def _ldap_addlist(self):
 		return [('objectClass', ['ast4ucsFax']),
 				('ast4ucsSrvchildServer', self.superordinate.dn)]

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/faxGroup.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/faxGroup.py
@@ -21,6 +21,7 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/faxGroup"
 short_description = u"Asterisk4UCS-Management: Faxgruppe"
@@ -60,41 +61,9 @@ mapping.register("extension", "ast4ucsExtensionExtension",
 	None, univention.admin.mapping.ListToString)
 mapping.register("members", "ast4ucsFaxgroupMember")
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
 
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
-	
 	def _ldap_addlist(self):
 		return [('objectClass', ['ast4ucsFaxgroup']),
 				('ast4ucsSrvchildServer', self.superordinate.dn)]

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
@@ -21,6 +21,7 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/mailbox"
 short_description = u"Asterisk4UCS-Management: Anrufbeantworter"
@@ -77,55 +78,8 @@ mapping.register("password", "ast4ucsMailboxPassword",
 mapping.register("email", "ast4ucsMailboxNotifybymail",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
-
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		"""Wird von __init__ (siehe oben) aufgerufen.
-		Falls das Superordinate-Object dieses Objects nicht bereits
-		bekannt ist (weil es als Argument an __init__ übergeben wurde),
-		versucht diese Funktion das Superordinate aus dem LDAP
-		auszulesen, zu öffnen, und in self.superordinate zu
-		referenzieren.
-
-		Diese Funktionalität erleichtert es extrem, untergeordnete
-		Objekte zu modifizieren und wird von den UMC-Modulen
-		(insbesondere dem Musikupload) oft genutzt. Die von
-		Univention definierten Module haben diese Funktion nicht.
-		(Um diese modifizieren zu können muss man also von Hand erst
-		das übergeordnete Objekt öffnen, und dann dieses beim
-		Aufruf von __init__ übergeben)"""
-
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
 
 	def _ldap_pre_ready(self):
 		"""Wird vor der Syntaxprüfung der Eingabefelder aufgerufen und

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/music.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/music.py
@@ -21,6 +21,7 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/music"
 short_description = u"Asterisk4UCS-Management: Warteschlangenmusik"
@@ -57,41 +58,9 @@ mapping.register("name", "cn",
 mapping.register("music", "ast4ucsMusicMusic",
 	None, None)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
 
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
-	
 	def _ldap_addlist(self):
 		return [('objectClass', ['ast4ucsMusic']),
 				('ast4ucsSrvchildServer', self.superordinate.dn)]

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneGroup.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneGroup.py
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import univention.admin.filter
 import univention.admin.handlers
 from univention.admin.handlers.asterisk import \
-	reverseFieldsLoad, reverseFieldsSave
+	reverseFieldsLoad, reverseFieldsSave, AsteriskBase
 import univention.admin.syntax
 from univention.admin.layout import Tab
 
@@ -78,7 +78,7 @@ mapping.register("commonName", "cn",
 mapping.register("id", "ast4ucsPhonegroupId",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
 
 	def __init__(self, co, lo, position, dn='', superordinate=None,
@@ -87,39 +87,10 @@ class object(univention.admin.handlers.simpleLdap):
 			("pickupphones", "asterisk/sipPhone", "pickupgroups"),
 			("callphones", "asterisk/sipPhone", "callgroups"),
 		]
-
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
+		super(object, self).__init__(self, co, lo, position, dn, superordinate)
 
 	def open(self):
-		univention.admin.handlers.simpleLdap.open(self)
+		super(object, self).open(self)
 		reverseFieldsLoad(self)
 		self.save()
 
@@ -128,11 +99,11 @@ class object(univention.admin.handlers.simpleLdap):
 		reverseFieldsSave(self)
 	
 	def _ldap_pre_modify(self):
-		super(object, self)_ldap_pre_modify()
+		super(object, self)._ldap_pre_modify()
 		reverseFieldsSave(self)
 	
 	def _ldap_pre_remove(self):
-		super(object, self)_ldap_pre_remove()
+		super(object, self)._ldap_pre_remove()
 		self.open()
 		self.info = {}
 		reverseFieldsSave(self)

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneType.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneType.py
@@ -21,6 +21,7 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/phoneType"
 short_description = u"Asterisk4UCS-Management: Telefontyp"
@@ -69,40 +70,8 @@ mapping.register("manufacturer", "ast4ucsPhonetypeManufacturer",
 mapping.register("type", "ast4ucsPhonetypeType",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
-
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
 
 	def _ldap_addlist(self):
 		return [('objectClass', ['ast4ucsPhonetype']),

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/sipPhone.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/sipPhone.py
@@ -21,6 +21,7 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
+from univention.admin.handlers.asterisk import AsteriskBase
 
 module = "asterisk/sipPhone"
 short_description = u"Asterisk4UCS-Management: IP-Telefon"
@@ -141,40 +142,8 @@ mapping.register("forwarding", "ast4ucsPhoneForwarding",
 mapping.register("skipExtension", "ast4ucsPhoneSkipextension",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
-
-	def __init__(self, co, lo, position, dn='', superordinate=None,
-			attributes=[]):
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present. The assigned phone for this user was deleted!'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
 
 	def _ldap_addlist(self):
 		return [('objectClass', ['ast4ucsPhone']),

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/waitingLoop.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/waitingLoop.py
@@ -20,7 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import univention.admin.filter
 import univention.admin.handlers
 from univention.admin.handlers.asterisk import \
-	reverseFieldsLoad, reverseFieldsSave
+	reverseFieldsLoad, reverseFieldsSave, AsteriskBase
 import univention.admin.syntax
 from univention.admin.layout import Tab
 
@@ -113,7 +113,7 @@ mapping.register("memberDelay", "ast4ucsWaitingloopMemberdelay",
 mapping.register("delayMusic", "ast4ucsWaitingloopDelaymusic",
 	None, univention.admin.mapping.ListToString)
 
-class object(univention.admin.handlers.simpleLdap):
+class object(AsteriskBase):
 	module=module
 
 	def __init__(self, co, lo, position, dn='', superordinate=None,
@@ -122,38 +122,10 @@ class object(univention.admin.handlers.simpleLdap):
 			("members", "asterisk/sipPhone", "waitingloops"),
 		]
 
-		univention.admin.handlers.simpleLdap.__init__(self, co, lo, 
-			position, dn, superordinate)
-
-		self.openSuperordinate()
-		if not self.superordinate:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'superordinate object not present'
-		if not dn and not position:
-			raise univention.admin.uexceptions.insufficientInformation, \
-					 'neither DN nor position present'
-
-	def openSuperordinate(self):
-		if self.superordinate:
-			return
-
-		self.open()
-		serverdn = self.oldattr.get("ast4ucsSrvchildServer")
-		if not serverdn:
-			return
-
-		if serverdn.__iter__:
-			serverdn = serverdn[0]
-
-		univention.admin.modules.update()
-		servermod = univention.admin.modules.get("asterisk/server")
-		univention.admin.modules.init(self.lo, self.position, servermod)
-		self.superordinate = servermod.object(self.co, self.lo,
-				self.position, serverdn)
-		self.superordinate.open()
+		super(object, self).__init__(self, co, lo, position, dn, superordinate)
 
 	def open(self):
-		univention.admin.handlers.simpleLdap.open(self)
+		super(object, self).open(self)
 		reverseFieldsLoad(self)
 		self.save()
 


### PR DESCRIPTION
A first version to fix Bug #11022 / Issue #5.

There are still multiple problems by the changes of:
https://forge.univention.org/bugzilla/show_bug.cgi?id=42177
https://forge.univention.org/bugzilla/show_bug.cgi?id=34764

Can you have a look with this version, if you find issues?

I added some workaround code, to prevent some UDM checks we introduced:
E.g. in the UCS handlers all objects lie underneath of their supoerordinate. This is not the case here.
It might be the best to get rid of the superordinate concept in all asterisk handlers.
As far as I can see, there is only one asterisk/server object in the whole domain which is the superordinate and gets written into the attribute "ast4ucsSrvchildServer". This could be solved without superordinates.

For asterisk/contact I am unsure. There are probably more than one asterisk/phoneGroup object?