### PR TITLE
Remove deprecated code

### DIFF
--- a/asterisk4ucs-umc-deploy/umc/python/asteriskDeploy/__init__.py
+++ b/asterisk4ucs-umc-deploy/umc/python/asteriskDeploy/__init__.py
@@ -15,13 +15,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import univention.management.console.modules
-from univention.management.console.protocol.definitions import SUCCESS
+from univention.management.console.base import Base
 from univention.management.console.log import MODULE
+from univention.management.console.config import ucr
 
-import univention.config_registry
 import univention.admin.uldap
-import univention.admin.config
 
 import univention.admin.modules
 univention.admin.modules.update()
@@ -38,10 +36,8 @@ import shutil
 import tempfile
 import subprocess
 
-ucr = univention.config_registry.ConfigRegistry()
-ucr.load()
+class Instance(Base):
 
-class Instance(univention.management.console.modules.Base):
 	def queryServers(self, request):
 		servers = getServers()
 		result = []
@@ -61,7 +57,6 @@ class Instance(univention.management.console.modules.Base):
 		self.finished(request.id, True)
 
 	def create(self, request):
-		
 		server = getServer(request.options["server"])
 		MODULE.error('### request: %s' % request)
 		MODULE.error('### self: %s' % self)
@@ -95,8 +90,7 @@ class Instance(univention.management.console.modules.Base):
 
 
 def getCoLoPos():
-	co = univention.admin.config.config()
-
+	co = None
 	lo, pos = univention.admin.uldap.getAdminConnection()
 
 	return co, lo, pos

--- a/asterisk4ucs-umc-music/umc/python/asteriskMusic/__init__.py
+++ b/asterisk4ucs-umc-music/umc/python/asteriskMusic/__init__.py
@@ -14,13 +14,10 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
-import univention.management.console.modules
-from univention.management.console.protocol.definitions import SUCCESS
+from univention.management.console.base import Base
 from univention.management.console.log import MODULE
 
-import univention.config_registry
 import univention.admin.uldap
-import univention.admin.config
 
 import univention.admin.modules
 univention.admin.modules.update()
@@ -38,10 +35,10 @@ import logging
 logfile = "/var/log/univention/asteriskMusicPython.log"
 logFilename = "/var/log/univention/asteriskMusicUpload.log"
 
-class Instance(univention.management.console.modules.Base):
+class Instance(Base):
 	logging.basicConfig(filename=logfile,
 		#level=logging.INFO,
-          level=logging.DEBUG,
+		level=logging.DEBUG,
 		format = "%(asctime)s\t%(levelname)s\t%(message)s",
 		datefmt = "%d.%m.%Y %H:%M:%S"
 		)
@@ -54,7 +51,6 @@ class Instance(univention.management.console.modules.Base):
 				"label": server["commonName"],
 			})
 
-		request.status = SUCCESS
 		self.finished(request.id, result)
 
 	def queryMohs(self, request):
@@ -68,7 +64,6 @@ class Instance(univention.management.console.modules.Base):
 					"label": moh["name"],
 				})
 
-		request.status = SUCCESS
 		self.finished(request.id, result)
 
 	def querySongs(self, request):
@@ -90,7 +85,6 @@ class Instance(univention.management.console.modules.Base):
 				"name": song,
 			})
 
-		request.status = SUCCESS
 		self.finished(request.id, result)
 
 	def create(self, request):
@@ -101,7 +95,6 @@ class Instance(univention.management.console.modules.Base):
 			"newDn": create(server, name),
 		}
 
-		request.status = SUCCESS
 		self.finished(request.id, result)
 
 	def delete(self, request):
@@ -110,7 +103,6 @@ class Instance(univention.management.console.modules.Base):
 		delete(moh)
 		moh.remove()
 
-		request.status = SUCCESS
 		self.finished(request.id, True)
 
 	def upload(self, request):
@@ -143,15 +135,13 @@ class Instance(univention.management.console.modules.Base):
 		if uploadMusic(server, moh, data, stem, filename):
 			moh.info.setdefault("music", []).append(stem)
 			moh.modify()
-			request.status = SUCCESS
 			self.finished(request.id, {"foo":"bar"})
 		else:
 			log = open(logFilename).read()
-			request.status = SUCCESS
 			self.finished(request.id, {"error": log})
 
 def getCoLoPos():
-	co = univention.admin.config.config()
+	co = None
 	#logging.debug('__init__.py: co: %s',co)"""
 	lo, pos = univention.admin.uldap.getAdminConnection()
 	#logging.debug('__init__.py: lo: %s pos: %s',lo, pos)


### PR DESCRIPTION
univention.management.console.protocol.definitions is deprecated and
going to be removed in UCS 5.
request.status = SUCCESS is implicit done.

univention.admin.config is deprecated and can be replaced with None:
https://forge.univention.org/bugzilla/show_bug.cgi?id=27804