### PR TITLE
Add missing save() call at the end of open()

### DIFF
--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/server.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/server.py
@@ -293,7 +293,8 @@ class object(univention.admin.handlers.simpleLdap):
 			self.info["blockInternational"] = "1"
 			for areaCode in ["+", "00"]:
 				self.info["blockedAreaCodes"].remove(areaCode)
-		# it looks like self.save() is missing here because if self.info is modified and save is not called the difference is not detected!
+
+		self.save()
 
 	def saveCheckboxes(self):
 		if "1" in self.info.get("blockInternational",[]):


### PR DESCRIPTION
If changes in self.info are done, self.save() writes them into
self.oldinfo.
When modifying/creating the object self.oldinfo and self.info are
compared and the changes are written to LDAP. As there no save() call is
done the change can't be detected.

Probably open() (and therefore save()) was called mutliple times, so that this never occurred as bug
and this change is not a regression.

open() was e.g. called in openSuperordinate.