### PR TITLE
Add UCS 5.0 and Python 3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Asterisk4UCS ermöglicht zentrale Administration der gesamten Asterisk-Konfiguration mit allen Telefonen, Benutzerzuordnungen und weiteren IP-Telefonie-Peripheriegeräten/ -merkmalen und ist als App für den Univention Corporate Server (UCS) erhältlich. Der UCS stellt ein zentrales Identity- und Infrastruktur-Management basierend auf OpenLDAP zur Verfügung, in dem alle Teilnehmer mit ihren Login-Daten an einer Stelle im Netzwerk gehalten werden. Asterisk4UCS stellt die IP-Telefonie-Informationen dort bereit, wo sie benötigt werden: auf dem zentralen Anmeldesystemserver.
 
-Asterisk4UCS erweitert eines der führenden LDAP-Verwaltungssysteme, den Univention Corporate Server (UCS) [1], um IP-Telefonie-Verwaltungsmöglichkeiten über eine web-basierte Oberfläche mit Hilfe eines dafür entwickelten UDM-Moduls (Univention Directory Management).
+Ab UCS Version 4.3 wird Asterisk4UCS nicht mehr von uns gepflegt (end-of-life) und wird im Univention App Katalog deaktiviert. Als Hersteller der Lösung stehen wir Ihnen bei Fragen gerne zur Seite. Asterisk4UCS wurde zu unserer IP-Telefonanlage KITOMA weiterentwickelt. KITOMA ist statt reinen Administrationsmanagements nunmehr eine komplette IP-Telefonanlage, auf die durch die KITOMA-Oberfläche direkt zugegriffen werden kann. 
 
-Mehr Informationen unter http://www.asterisk4ucs.de oder https://www.decoit.de
+Zwar ist KITOMA nicht direkt über den App-Katalog herunterladbar, aber trotzdem kompatibel zu UCS, so dass wir als Univention Premium Partner gerne Ihre UCS-Infrastruktur durch unsere IP-Telefonanlage erweitern. Weitere Informationen finden Sie unter www.kito.ma oder unter www.decoit.de/voip.html
+
+Viele Grüße vom DECOIT®-Team
 
 ## Repository-Struktur
 Der Master enthält die neuste Release-Version. Daneben gibt es noch spezifische Branches für die einzelnen UCS-Versionen, wie z.B. 4.1 oder 4.2.

--- a/asterisk4ucs-testasterisk/debian/changelog
+++ b/asterisk4ucs-testasterisk/debian/changelog
@@ -1,3 +1,9 @@
+asterisk4ucs-testasterisk (2.0.1) unstable; urgency=medium
+
+  * Add UCS 5.0 support. Migrate to Python 3
+
+ -- Florian Best <best@univention.de>  Sun, 03 Apr 2022 20:56:35 +0200
+
 asterisk4ucs-testasterisk (1.0.1) unstable; urgency=low
 
   * Nichtinteraktive Installation repariert

--- a/asterisk4ucs-udm/42asterisk4ucs-udm.inst
+++ b/asterisk4ucs-udm/42asterisk4ucs-udm.inst
@@ -30,4 +30,3 @@ umc_policy_append "default-umc-all" "udm-asterisk"
 joinscript_save_current_version
 
 exit 0
-

--- a/asterisk4ucs-udm/conffiles/etc/ldap/slapd.conf.d/80asterisk
+++ b/asterisk4ucs-udm/conffiles/etc/ldap/slapd.conf.d/80asterisk
@@ -1,7 +1,5 @@
 @%@UCRWARNING=# @%@
 @!@
-if baseConfig['server/role'] == "domaincontroller_master":
-        print "include /usr/share/univention-ldap/schema/asterisk4ucs.schema"
+if configRegistry['server/role'] == "domaincontroller_master":
+	print("include /usr/share/univention-ldap/schema/asterisk4ucs.schema")
 @!@
-
-

--- a/asterisk4ucs-udm/debian/asterisk4ucs-udm.postinst
+++ b/asterisk4ucs-udm/debian/asterisk4ucs-udm.postinst
@@ -25,8 +25,8 @@ udm container/cn create \
 /usr/lib/asterisk4ucs/user-phone-extension/install
 
 # this is madness! - no, this is pkiiiiiiiiilllll!!!!
-pkill -f '/usr/bin/python /usr/sbin/univention-management-console-module -m udm .*'
-pkill -f '/usr/bin/python /usr/share/univention-directory-manager-tools/univention-cli-server'
+pkill -f '/usr/bin/python3 /usr/sbin/univention-management-console-module -m udm .*'
+pkill -f '/usr/bin/python3 /usr/share/univention-directory-manager-tools/univention-cli-server'
 /etc/init.d/univention-management-console-web-server stop
 /etc/init.d/univention-management-console-server restart
 /etc/init.d/univention-management-console-web-server start

--- a/asterisk4ucs-udm/debian/changelog
+++ b/asterisk4ucs-udm/debian/changelog
@@ -1,3 +1,9 @@
+asterisk4ucs-udm (2.0.1) unstable; urgency=medium
+
+  * Add UCS 5.0 support. Migrate to Python 3
+
+ -- Florian Best <best@univention.de>  Sun, 03 Apr 2022 20:58:30 +0200
+
 asterisk4ucs-udm (1.0.0) unstable; urgency=low
 
   * Einige Bugfixes, Vorbereitung auf Release

--- a/asterisk4ucs-udm/debian/control
+++ b/asterisk4ucs-udm/debian/control
@@ -5,7 +5,7 @@ Maintainer: Tristan Bruns (Decoit GmbH) <bruns@decoit.de>
 Build-Depends:
  debhelper (>= 7.0.50~),
  univention-config-dev,
- python-univention
+ python3-univention
 Standards-Version: 3.5.2
 
 Package: asterisk4ucs-udm

--- a/asterisk4ucs-udm/devscripts/hardrestart
+++ b/asterisk4ucs-udm/devscripts/hardrestart
@@ -15,4 +15,4 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-kill -9 `ps aux | grep management-console | cut -d\  -f 7` ; /etc/init.d/univention-management-console-server start && /etc/init.d/univention-management-console-web-server start
+systemctl restart univention-management-console-server

--- a/asterisk4ucs-udm/modules/asterisk4ucs/__init__.py
+++ b/asterisk4ucs-udm/modules/asterisk4ucs/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # coding=utf-8
 
 """
@@ -20,7 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import univention.admin.config
 import univention.admin.uldap
 import univention.admin.modules
 
@@ -35,16 +34,15 @@ class PhoneBookWrapper(object):
 		pbdn ist der DN des Telefonbuches im LDAP. (Kann z.B. per
 		"udm asterisk/phoneBook list" ermittelt werden)"""
 
-		self.co = univention.admin.config.config()
 		self.lo, self.pos = univention.admin.uldap.getAdminConnection()
 
 		univention.admin.modules.update()
 		self.udmPhonebook = univention.admin.modules.get("asterisk/phoneBook")
-		self.udmContact = univention.admin.modules.get("asterisk/contact")
 		univention.admin.modules.init(self.lo, self.pos, self.udmPhonebook)
+		self.udmContact = univention.admin.modules.get("asterisk/contact")
 		univention.admin.modules.init(self.lo, self.pos, self.udmContact)
 
-		self.pb = self.udmPhonebook.object(self.co, self.lo, None, pbdn)
+		self.pb = self.udmPhonebook.object(None, self.lo, None, pbdn)
 		self.pb.open()
 		if not self.pb.exists():
 			raise Exception("DN does not exist.")
@@ -57,7 +55,7 @@ class PhoneBookWrapper(object):
 	def empty(self):
 		"""Löscht alle Kontakte im Telefonbuch"""
 
-		contacts = self.udmContact.lookup(self.co, self.lo, None, superordinate=self.pb)
+		contacts = self.udmContact.lookup(None, self.lo, None, superordinate=self.pb)
 
 		for contact in contacts:
 			contact.remove()
@@ -76,7 +74,7 @@ class PhoneBookWrapper(object):
 		Strings.
 		Der Rückgabewert ist der DN des neuen Kontakts."""
 
-		contact = self.udmContact.object(self.co, self.lo, self.pb.position, None, self.pb)
+		contact = self.udmContact.object(None, self.lo, self.pb.position, None, self.pb)
 		contact.open()
 
 		if title:

--- a/asterisk4ucs-udm/modules/asterisk4ucs/__init__.py
+++ b/asterisk4ucs-udm/modules/asterisk4ucs/__init__.py
@@ -20,9 +20,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import re
-import sys
-
 import univention.admin.config
 import univention.admin.uldap
 import univention.admin.modules
@@ -42,20 +39,15 @@ class PhoneBookWrapper(object):
 		self.lo, self.pos = univention.admin.uldap.getAdminConnection()
 
 		univention.admin.modules.update()
-		self.udmPhonebook = univention.admin.modules.get(
-				"asterisk/phoneBook")
-		self.udmContact = univention.admin.modules.get(
-				"asterisk/contact")
-		univention.admin.modules.init(self.lo, self.pos,
-				self.udmPhonebook)
-		univention.admin.modules.init(self.lo, self.pos,
-				self.udmContact)
+		self.udmPhonebook = univention.admin.modules.get("asterisk/phoneBook")
+		self.udmContact = univention.admin.modules.get("asterisk/contact")
+		univention.admin.modules.init(self.lo, self.pos, self.udmPhonebook)
+		univention.admin.modules.init(self.lo, self.pos, self.udmContact)
 
-		self.pb = self.udmPhonebook.object(self.co, self.lo,
-				None, pbdn)
+		self.pb = self.udmPhonebook.object(self.co, self.lo, None, pbdn)
 		self.pb.open()
 		if not self.pb.exists():
-			raise Exception, "DN does not exist."
+			raise Exception("DN does not exist.")
 
 	def getName(self):
 		"""Gibt den Namen des Telefonbuchs zurück"""
@@ -65,17 +57,14 @@ class PhoneBookWrapper(object):
 	def empty(self):
 		"""Löscht alle Kontakte im Telefonbuch"""
 
-		contacts = self.udmContact.lookup(self.co, self.lo, None,
-				superordinate=self.pb)
+		contacts = self.udmContact.lookup(self.co, self.lo, None, superordinate=self.pb)
 
 		for contact in contacts:
 			contact.remove()
 
 		return len(contacts)
 
-	def addContact(self, title=None, firstname=None, lastname=None,
-			organisation=None,
-			phones=None, mobiles=None, faxes=None):
+	def addContact(self, title=None, firstname=None, lastname=None, organisation=None, phones=None, mobiles=None, faxes=None):
 		"""Fügt einen Kontakt hinzu
 
 		Die Argumente sollten unbedingt als Keyword-Argumente
@@ -87,8 +76,7 @@ class PhoneBookWrapper(object):
 		Strings.
 		Der Rückgabewert ist der DN des neuen Kontakts."""
 
-		contact = self.udmContact.object(self.co, self.lo,
-				self.pb.position, None, self.pb)
+		contact = self.udmContact.object(self.co, self.lo, self.pb.position, None, self.pb)
 		contact.open()
 
 		if title:

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
+
 from univention.management.console.log import MODULE
 import univention.config_registry
 import univention.admin.filter
@@ -563,11 +564,3 @@ def reverseFieldsSave(self):
 			obj.open()
 			obj.info.setdefault(foreignField, []).append(self.dn)
 			obj.modify()
-
-
-class AsteriskBase(univention.admin.handlers.simpleLdap):
-
-	def __init__(self, co, lo, position, dn='', superordinate=None, attributes=None):
-		if not superordinate and (dn or position):
-			superordinate = univention.admin.objects.get_superordinate(self.module, co, lo, dn or position.getDn())
-		super(AsteriskBase, self).__init__(co, lo, position, dn, superordinate, attributes)

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
@@ -110,10 +110,10 @@ def genSipconfEntry(co, lo, phone):
 
 
 def genSipconfFaxEntry(co, lo, phone):
-	res = "[%s]\n" % (phone["extension"])
+	res = "[%s]\n" % (phone["extension"],)
 	res += "type=friend\n"
 	res += "host=dynamic\n"
-	res += "secret=%s\n" % (phone["password"])
+	res += "secret=%s\n" % (phone["password"],)
 	return res
 
 
@@ -159,7 +159,7 @@ def genSipconf(co, lo, srv):
 def genVoicemailconfEntry(co, lo, box):
 	from univention.admin.handlers.users import user
 	boxUser = user.lookup(co, lo, filter_format("(ast4ucsUserMailbox=%s)", (box.dn,)))
-	if len(boxUser) == 0:
+	if not boxUser:
 		return ";; Mailbox %s has no user.\n" % box["id"]
 	if len(boxUser) > 1:
 		msg = ";; Mailbox %s has multiple users:\n" % box["id"]

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/__init__.py
@@ -71,8 +71,7 @@ def genSipconfEntry(co, lo, phone):
 	phone = phone.info
 
 	if phoneUser.get("mailbox"):
-		phoneMailbox = mailbox.object(co, lo, None,
-			phoneUser["mailbox"]).info
+		phoneMailbox = mailbox.object(co, lo, None, phoneUser["mailbox"]).info
 
 	callgroups = []
 	for group in phone.get("callgroups", []):
@@ -84,9 +83,7 @@ def genSipconfEntry(co, lo, phone):
 		group = phoneGroup.object(co, lo, None, group).info
 		pickupgroups.append(group["id"])
 
-	res = "[%s](template-%s)\n" % (
-			phone["extension"],
-			phone.get("profile", "default"))
+	res = "[%s](template-%s)\n" % (phone["extension"], phone.get("profile", "default"))
 	res += "secret=%s\n" % (phone["password"])
 
 	if phoneUser.get("extmode") == "normal":
@@ -94,8 +91,7 @@ def genSipconfEntry(co, lo, phone):
 			getNameFromUser(phoneUser),
 			phone["extension"])
 	elif phoneUser.get("extmode") == "first":
-		firstPhone = sipPhone.object(co, lo, None,
-			llist(phoneUser["phones"])[0]).info
+		firstPhone = sipPhone.object(co, lo, None, llist(phoneUser["phones"])[0]).info
 		res += "callerid=\"%s\" <%s>\n" % (
 			getNameFromUser(phoneUser),
 			firstPhone["extension"])
@@ -143,9 +139,8 @@ def genSipconf(co, lo, srv):
 		conf += "; dn: %s\n" % (phone.dn)
 		try:
 			conf += genSipconfEntry(co, lo, phone)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	conf += "\n\n; ===== Fax machines =====\n\n"
@@ -153,9 +148,8 @@ def genSipconf(co, lo, srv):
 		conf += "; dn: %s\n" % (phone.dn)
 		try:
 			conf += genSipconfFaxEntry(co, lo, phone)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	return conf
@@ -211,9 +205,8 @@ def genVoicemailconf(co, lo, srv):
 		conf += "; dn: %s\n" % (box.dn)
 		try:
 			conf += genVoicemailconfEntry(co, lo, box)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	return conf
@@ -246,9 +239,8 @@ def genQueuesconf(co, lo, srv):
 		conf += "; dn: %s\n" % (queue.dn)
 		try:
 			conf += genQueuesconfEntry(co, lo, queue)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	return conf
@@ -277,9 +269,8 @@ def genMusiconholdconf(co, lo, srv):
 		conf += "; dn: %s\n" % (moh.dn)
 		try:
 			conf += genMusiconholdconfEntry(co, lo, srv, moh)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	return conf
@@ -290,8 +281,7 @@ def genExtSIPPhoneEntry(co, lo, agis, extenPhone):
 
 	# check if this phone is managed manually (not by ast4ucs)
 	if extenPhone.get("skipExtension") == "1":
-		return ";; Extension %s is managed manually.\n" % (
-				extenPhone["extension"])
+		return ";; Extension %s is managed manually.\n" % (extenPhone["extension"],)
 
 	from univention.admin.handlers.users import user
 	from univention.admin.handlers.asterisk import sipPhone, mailbox
@@ -311,22 +301,21 @@ def genExtSIPPhoneEntry(co, lo, agis, extenPhone):
 	try:
 		timeout = int(phoneUser["timeout"])
 		if timeout < 1 or timeout > 120:
-			raise Exception
-	except:
+			raise ValueError()
+	except ValueError:
 		timeout = 10
 
 	try:
 		ringdelay = int(phoneUser["ringdelay"])
 		if ringdelay < 1 or ringdelay > 120:
-			raise Exception
-	except:
+			raise ValueError()
+	except ValueError:
 		ringdelay = 0
 
 	channels = []
 	hints = []
 	for dn in phoneUser.get("phones", []):
-		phone = sipPhone.object(co, lo, extenPhone.position, dn,
-				extenPhone.superordinate)
+		phone = sipPhone.object(co, lo, extenPhone.position, dn, extenPhone.superordinate)
 		hints.append("SIP/%s" % phone["extension"])
 		if phone.get("forwarding"):
 			channels.append("Local/%s" % phone["forwarding"])
@@ -342,8 +331,7 @@ def genExtSIPPhoneEntry(co, lo, agis, extenPhone):
 	if channels:
 		if ringdelay:
 			for channel in channels[:-1]:
-				res.append("Dial(%s,%i,tT)" % (channel,
-						ringdelay))
+				res.append("Dial(%s,%i,tT)" % (channel, ringdelay))
 				res.append("Wait(0.5)")
 			res.append("Dial(%s,%i,tT)" % (channels[-1], timeout))
 		else:
@@ -360,10 +348,9 @@ def genExtSIPPhoneEntry(co, lo, agis, extenPhone):
 
 	resStr = ""
 	if hints:
-		resStr += "exten => %s,hint,%s\n" % (extension,
-				'&'.join(hints))
+		resStr += "exten => %s,hint,%s\n" % (extension, '&'.join(hints))
 	for i, data in enumerate(res):
-		resStr += "exten => %s,%i,%s\n" % (extension, i+1, data)
+		resStr += "exten => %s,%i,%s\n" % (extension, i + 1, data)
 
 	return resStr
 
@@ -463,8 +450,7 @@ def genExtensionsconf(co, lo, srv):
 			int(agi["priority"]),
 			"AGI(ast4ucs-%s)" % agi["name"]
 		))
-	sortkey = lambda x: x[0]
-	agis.sort(key=sortkey, reverse=True)
+	agis.sort(key=lambda x: x[0], reverse=True)
 	agis = [x[1] for x in agis]
 
 	conf = "; Automatisch generiert von Asterisk4UCS\n"
@@ -476,9 +462,8 @@ def genExtensionsconf(co, lo, srv):
 		conf += "; dn: %s\n" % (phone.dn)
 		try:
 			conf += genExtSIPPhoneEntry(co, lo, agis, phone)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	conf += "\n\n; ===== Konferenzräume =====\n\n"
@@ -486,9 +471,8 @@ def genExtensionsconf(co, lo, srv):
 		conf += "; dn: %s\n" % (room.dn)
 		try:
 			conf += genExtRoomEntry(co, lo, agis, room)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	conf += "\n\n; ===== Warteschleifen =====\n\n"
@@ -496,9 +480,8 @@ def genExtensionsconf(co, lo, srv):
 		conf += "; dn: %s\n" % (queue.dn)
 		try:
 			conf += genExtQueueEntry(co, lo, agis, queue)
-		except:
-			conf += re.sub("(?m)^", ";",
-				traceback.format_exc()[:-1])
+		except Exception:
+			conf += re.sub("(?m)^", ";", traceback.format_exc()[:-1])
 		conf += "\n"
 
 	conf += "\n\n; ===== Blockierte Vorwahlen =====\n\n"

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/agiscript.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/agiscript.py
@@ -61,12 +61,9 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("name", "cn",
-	None, univention.admin.mapping.ListToString)
-mapping.register("priority", "ast4ucsAgiscriptPriority",
-	None, univention.admin.mapping.ListToString)
-mapping.register("content", "ast4ucsAgiscriptContent",
-	None, univention.admin.mapping.ListToString)
+mapping.register("name", "cn", None, univention.admin.mapping.ListToString)
+mapping.register("priority", "ast4ucsAgiscriptPriority", None, univention.admin.mapping.ListToString)
+mapping.register("content", "ast4ucsAgiscriptContent", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
@@ -79,32 +76,25 @@ class object(AsteriskBase):
 		self["content"] = content.encode("base64").replace("\n", "")
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsAgiscript']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsAgiscript']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsAgiscript")
+		univention.admin.filter.expression('objectClass', "ast4ucsAgiscript")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/agiscript.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/agiscript.py
@@ -17,6 +17,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
+import base64
+
 import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
@@ -76,10 +78,10 @@ class object(simpleLdap):
 	module = module
 
 	def getContent(self):
-		return self.get("content", "").decode("base64")
+		return base64.b64decode(self.get("content", "").encode('UTF-8')).decode("ascii")
 
 	def setContent(self, content):
-		self["content"] = content.encode("base64").replace("\n", "")
+		self["content"] = base64.b64encode(content.encode("utf-8")).decode('ascii')
 
 	def _ldap_addlist(self):
 		return [('ast4ucsSrvchildServer', self.superordinate.dn)]

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/asterisk.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/asterisk.py
@@ -41,8 +41,8 @@ long_description = ''
 operations = ['search']
 default_containers = ["cn=asterisk"]
 
-childs = 0
-virtual = 1
+childs = False
+virtual = True
 
 modulesWithSuperordinates = {
 	"None": [

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/conferenceRoom.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/conferenceRoom.py
@@ -87,23 +87,15 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("extension", "ast4ucsExtensionExtension",
-	None, univention.admin.mapping.ListToString)
-mapping.register("maxMembers", "ast4ucsConfroomMaxmembers",
-	None, univention.admin.mapping.ListToString)
-mapping.register("pin", "ast4ucsConfroomPin",
-	None, univention.admin.mapping.ListToString)
-mapping.register("adminPin", "ast4ucsConfroomAdminpin",
-	None, univention.admin.mapping.ListToString)
+mapping.register("extension", "ast4ucsExtensionExtension", None, univention.admin.mapping.ListToString)
+mapping.register("maxMembers", "ast4ucsConfroomMaxmembers", None, univention.admin.mapping.ListToString)
+mapping.register("pin", "ast4ucsConfroomPin", None, univention.admin.mapping.ListToString)
+mapping.register("adminPin", "ast4ucsConfroomAdminpin", None, univention.admin.mapping.ListToString)
 
-mapping.register("announceCount", "ast4ucsConfroomAnnouncecount",
-	None, univention.admin.mapping.ListToString)
-mapping.register("initiallyMuted", "ast4ucsConfroomInitiallymuted",
-	None, univention.admin.mapping.ListToString)
-mapping.register("musicOnHold", "ast4ucsConfroomMusiconhold",
-	None, univention.admin.mapping.ListToString)
-mapping.register("quietMode", "ast4ucsConfroomQuietmode",
-	None, univention.admin.mapping.ListToString)
+mapping.register("announceCount", "ast4ucsConfroomAnnouncecount", None, univention.admin.mapping.ListToString)
+mapping.register("initiallyMuted", "ast4ucsConfroomInitiallymuted", None, univention.admin.mapping.ListToString)
+mapping.register("musicOnHold", "ast4ucsConfroomMusiconhold", None, univention.admin.mapping.ListToString)
+mapping.register("quietMode", "ast4ucsConfroomQuietmode", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
@@ -114,37 +106,30 @@ class object(AsteriskBase):
 		if self.info.get("pin"):
 			if self.info.get("adminPin") == self.info["pin"]:
 				class pinError(uexceptions.base):
-					message = "Pin und Admin-Pin dürfen " +\
-					"nicht übereinstimmen."
+					message = "Pin und Admin-Pin dürfen nicht übereinstimmen."
 				raise pinError
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsConfroom']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsConfroom']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
 		univention.admin.filter.expression(
 			'objectClass', "ast4ucsConfroom")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/contact.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/contact.py
@@ -84,24 +84,18 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("commonName", "cn",
-	None, univention.admin.mapping.ListToString)
-mapping.register("firstname", "ast4ucsContactFirstname",
-	None, univention.admin.mapping.ListToString)
-mapping.register("lastname", "ast4ucsContactLastname",
-	None, univention.admin.mapping.ListToString)
-mapping.register("title", "title",
-	None, univention.admin.mapping.ListToString)
-mapping.register("organisation", "o",
-	None, univention.admin.mapping.ListToString)
+mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
+mapping.register("firstname", "ast4ucsContactFirstname", None, univention.admin.mapping.ListToString)
+mapping.register("lastname", "ast4ucsContactLastname", None, univention.admin.mapping.ListToString)
+mapping.register("title", "title", None, univention.admin.mapping.ListToString)
+mapping.register("organisation", "o", None, univention.admin.mapping.ListToString)
 mapping.register("telephoneNumber", "telephoneNumber")
 mapping.register("mobileNumber", "ast4ucsContactMobilenumber")
 mapping.register("faxNumber", "ast4ucsContactFaxnumber")
 
 
 class noNameError(univention.admin.uexceptions.insufficientInformation):
-	message = (u"Eines der Felder Vorname, Nachname und Organisation "
-			u"muss ausgefüllt sein.")
+	message = (u"Eines der Felder Vorname, Nachname und Organisation muss ausgefüllt sein.")
 
 
 class object(AsteriskBase):
@@ -134,32 +128,25 @@ class object(AsteriskBase):
 		self.info["commonName"] = cn
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['phonebookContact']),
-				('ast4ucsPbchildPhonebook', self.superordinate.dn)]
+		return [('objectClass', ['phonebookContact']), ('ast4ucsPbchildPhonebook', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "phonebookContact")
+		univention.admin.filter.expression('objectClass', "phonebookContact")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsPbchildPhonebook', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsPbchildPhonebook', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/fax.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/fax.py
@@ -21,14 +21,19 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
-from univention.admin.handlers.asterisk import AsteriskBase
+from univention.admin.handlers import simpleLdap
 
 module = "asterisk/fax"
 short_description = u"Asterisk4UCS-Management: Fax"
 operations = ['add', 'edit', 'remove', 'search', 'move']
-options = {}
-
-childs = 0
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsFax'],
+	),
+}
+childs = False
 superordinate = "asterisk/server"
 
 layout = [
@@ -73,32 +78,18 @@ mapping.register("hostname", "ast4ucsSipclientHostname", None, univention.admin.
 mapping.register("password", "ast4ucsSipclientSecret", None, univention.admin.mapping.ListToString)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsFax']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsFax")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsFax' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/fax.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/fax.py
@@ -66,48 +66,37 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("extension", "ast4ucsExtensionExtension",
-	None, univention.admin.mapping.ListToString)
-mapping.register("ipaddress", "ast4ucsSipclientIp",
-	None, univention.admin.mapping.ListToString)
-mapping.register("macaddress", "ast4ucsSipclientMacaddr",
-	None, univention.admin.mapping.ListToString)
-mapping.register("hostname", "ast4ucsSipclientHostname",
-	None, univention.admin.mapping.ListToString)
-mapping.register("password", "ast4ucsSipclientSecret",
-	None, univention.admin.mapping.ListToString)
+mapping.register("extension", "ast4ucsExtensionExtension", None, univention.admin.mapping.ListToString)
+mapping.register("ipaddress", "ast4ucsSipclientIp", None, univention.admin.mapping.ListToString)
+mapping.register("macaddress", "ast4ucsSipclientMacaddr", None, univention.admin.mapping.ListToString)
+mapping.register("hostname", "ast4ucsSipclientHostname", None, univention.admin.mapping.ListToString)
+mapping.register("password", "ast4ucsSipclientSecret", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsFax']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsFax']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
 		univention.admin.filter.expression(
 			'objectClass', "ast4ucsFax")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/faxGroup.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/faxGroup.py
@@ -57,8 +57,7 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("extension", "ast4ucsExtensionExtension",
-	None, univention.admin.mapping.ListToString)
+mapping.register("extension", "ast4ucsExtensionExtension", None, univention.admin.mapping.ListToString)
 mapping.register("members", "ast4ucsFaxgroupMember")
 
 
@@ -66,32 +65,25 @@ class object(AsteriskBase):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsFaxgroup']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsFaxgroup']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsFaxgroup")
+		univention.admin.filter.expression('objectClass', "ast4ucsFaxgroup")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/faxGroup.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/faxGroup.py
@@ -21,14 +21,19 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
-from univention.admin.handlers.asterisk import AsteriskBase
+from univention.admin.handlers import simpleLdap
 
 module = "asterisk/faxGroup"
 short_description = u"Asterisk4UCS-Management: Faxgruppe"
 operations = ['add', 'edit', 'remove', 'search', 'move']
-options = {}
-
-childs = 0
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsFaxgroup'],
+	),
+}
+childs = False
 superordinate = "asterisk/server"
 
 layout = [
@@ -61,31 +66,18 @@ mapping.register("extension", "ast4ucsExtensionExtension", None, univention.admi
 mapping.register("members", "ast4ucsFaxgroupMember")
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsFaxgroup']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsFaxgroup")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsFaxgroup' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
@@ -69,14 +69,10 @@ property_descriptions = {
 # Definiert die Zuordnung von UDM-Attributen zu LDAP-Attributen.
 # http://wiki.univention.de/index.php?title=Entwicklung_und_Integration_eigener_Module_in_Univention_Directory_Manager#mapping
 mapping = univention.admin.mapping.mapping()
-mapping.register("commonName", "cn",
-	None, univention.admin.mapping.ListToString)
-mapping.register("id", "ast4ucsMailboxId",
-	None, univention.admin.mapping.ListToString)
-mapping.register("password", "ast4ucsMailboxPassword",
-	None, univention.admin.mapping.ListToString)
-mapping.register("email", "ast4ucsMailboxNotifybymail",
-	None, univention.admin.mapping.ListToString)
+mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
+mapping.register("id", "ast4ucsMailboxId", None, univention.admin.mapping.ListToString)
+mapping.register("password", "ast4ucsMailboxPassword", None, univention.admin.mapping.ListToString)
+mapping.register("email", "ast4ucsMailboxNotifybymail", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
@@ -100,8 +96,7 @@ class object(AsteriskBase):
 		Bei neuen Modulen müssen die objectClass und der Attributname
 		des Superordinate-Verweises angepasst werden"""
 
-		return [('objectClass', ['ast4ucsMailbox']),
-			('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsMailbox']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 # Sucht nach diesem Modul zugehörigen Objekten. Berücksichtigt dabei eventuell
 # übergebene Einschränkungen (filter_s) und übergeordnete Objekte
@@ -111,28 +106,22 @@ class object(AsteriskBase):
 # (in diesem Fall ast4ucsMailbox und ast4ucsSrvchildServer)
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsMailbox")
+		univention.admin.filter.expression('objectClass', "ast4ucsMailbox")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 # Funktion, die True zurückliefert, wenn dieses Modul für das übergebene

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
@@ -37,7 +37,6 @@ options = {
 childs = False
 superordinate = "asterisk/server"
 
-# Definiert das Layout der Eingabefelder in der Weboberfläche
 layout = [
 	Tab('Allgemein', 'Allgemeine Einstellungen', layout=[
 		["id"],
@@ -46,8 +45,6 @@ layout = [
 	])
 ]
 
-# Definiert die verschiedenen UDM-Attribute
-# http://wiki.univention.de/index.php?title=Entwicklung_und_Integration_eigener_Module_in_Univention_Directory_Manager#property-descriptions
 property_descriptions = {
 	"commonName": univention.admin.property(
 		short_description="Name",
@@ -72,8 +69,6 @@ property_descriptions = {
 	),
 }
 
-# Definiert die Zuordnung von UDM-Attributen zu LDAP-Attributen.
-# http://wiki.univention.de/index.php?title=Entwicklung_und_Integration_eigener_Module_in_Univention_Directory_Manager#mapping
 mapping = univention.admin.mapping.mapping()
 mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
 mapping.register("id", "ast4ucsMailboxId", None, univention.admin.mapping.ListToString)

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/mailbox.py
@@ -21,14 +21,20 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
-from univention.admin.handlers.asterisk import AsteriskBase
+from univention.admin.handlers import simpleLdap
 
 module = "asterisk/mailbox"
 short_description = u"Asterisk4UCS-Management: Anrufbeantworter"
 operations = ['add', 'edit', 'remove', 'search', 'move']
-options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsMailbox'],
+	),
+}
 
-childs = 0
+childs = False
 superordinate = "asterisk/server"
 
 # Definiert das Layout der Eingabefelder in der Weboberfläche
@@ -75,7 +81,7 @@ mapping.register("password", "ast4ucsMailboxPassword", None, univention.admin.ma
 mapping.register("email", "ast4ucsMailboxNotifybymail", None, univention.admin.mapping.ListToString)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def _ldap_pre_ready(self):
@@ -96,37 +102,14 @@ class object(AsteriskBase):
 		Bei neuen Modulen müssen die objectClass und der Attributname
 		des Superordinate-Verweises angepasst werden"""
 
-		return [('objectClass', ['ast4ucsMailbox']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
 
-# Sucht nach diesem Modul zugehörigen Objekten. Berücksichtigt dabei eventuell
-# übergebene Einschränkungen (filter_s) und übergeordnete Objekte
-# (superordinate).
-# Für neue Module müssen in diesem Code nur die objectClass und das
-# LDAP-Attribut für die Superordinate-Zuordnung angepasst werden.
-# (in diesem Fall ast4ucsMailbox und ast4ucsSrvchildServer)
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsMailbox")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-# Funktion, die True zurückliefert, wenn dieses Modul für das übergebene
-# Objekt zuständig ist. Prüft einfach nur die LDAP objectClass.
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsMailbox' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/music.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/music.py
@@ -21,14 +21,21 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
-from univention.admin.handlers.asterisk import AsteriskBase
+from univention.admin.handlers import simpleLdap
 
 module = "asterisk/music"
 short_description = u"Asterisk4UCS-Management: Warteschlangenmusik"
 operations = ['add', 'edit', 'remove', 'search', 'move']
 options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsMusic'],
+	),
+}
 
-childs = 0
+childs = False
 superordinate = "asterisk/server"
 
 layout = [
@@ -57,31 +64,18 @@ mapping.register("name", "cn", None, univention.admin.mapping.ListToString)
 mapping.register("music", "ast4ucsMusicMusic", None, None)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsMusic']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsMusic")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsMusic' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/music.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/music.py
@@ -53,42 +53,33 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("name", "cn",
-	None, univention.admin.mapping.ListToString)
-mapping.register("music", "ast4ucsMusicMusic",
-	None, None)
+mapping.register("name", "cn", None, univention.admin.mapping.ListToString)
+mapping.register("music", "ast4ucsMusicMusic", None, None)
 
 
 class object(AsteriskBase):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsMusic']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsMusic']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsMusic")
+		univention.admin.filter.expression('objectClass', "ast4ucsMusic")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneBook.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneBook.py
@@ -46,8 +46,7 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("commonName", "cn",
-	None, univention.admin.mapping.ListToString)
+mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
 
 
 class object(univention.admin.handlers.simpleLdap):
@@ -57,24 +56,19 @@ class object(univention.admin.handlers.simpleLdap):
 		return [('objectClass', ['ast4ucsPhonebook'])]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsPhonebook")
+		univention.admin.filter.expression('objectClass', "ast4ucsPhonebook")
 	])
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneBook.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneBook.py
@@ -25,7 +25,13 @@ from univention.admin.layout import Tab
 module = "asterisk/phoneBook"
 short_description = u"Asterisk4UCS-Management: Telefonbuch"
 operations = ['add', 'edit', 'remove', 'search', 'move']
-options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsPhonebook'],
+	),
+}
 
 childs = False
 childmodules = ["asterisk/contact"]
@@ -52,25 +58,7 @@ mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString
 class object(univention.admin.handlers.simpleLdap):
 	module = module
 
-	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhonebook'])]
 
-
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsPhonebook")
-	])
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsPhonebook' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneGroup.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneGroup.py
@@ -20,14 +20,20 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import univention.admin.filter
 import univention.admin.handlers
 from univention.admin.handlers.asterisk import \
-	reverseFieldsLoad, reverseFieldsSave, AsteriskBase
+	reverseFieldsLoad, reverseFieldsSave, simpleLdap
 import univention.admin.syntax
 from univention.admin.layout import Tab
 
 module = "asterisk/phoneGroup"
 short_description = u"Asterisk4UCS-Management: Telefongruppe"
 operations = ['add', 'edit', 'remove', 'search', 'move']
-options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsPhonegroup'],
+	),
+}
 
 childs = False
 superordinate = "asterisk/server"
@@ -77,7 +83,7 @@ mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString
 mapping.register("id", "ast4ucsPhonegroupId", None, univention.admin.mapping.ListToString)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def __init__(self, co, lo, position, dn='', superordinate=None, attributes=None):
@@ -107,27 +113,14 @@ class object(AsteriskBase):
 		reverseFieldsSave(self)
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhonegroup']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsPhonegroup")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsPhonegroup' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneGroup.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneGroup.py
@@ -55,28 +55,26 @@ property_descriptions = {
 	"callphones": univention.admin.property(
 		short_description="Callgroup-Teilnehmer",
 		syntax=univention.admin.syntax.LDAP_Search(
-                        filter="objectClass=ast4ucsPhone",
-                        attribute=['asterisk/sipPhone: extension'],
-                        value='asterisk/sipPhone: dn',
-                ),
+			filter="objectClass=ast4ucsPhone",
+			attribute=['asterisk/sipPhone: extension'],
+			value='asterisk/sipPhone: dn',
+		),
 		multivalue=True,
 	),
 	"pickupphones": univention.admin.property(
 		short_description="Pickupgroup-Teilnehmer",
 		syntax=univention.admin.syntax.LDAP_Search(
-                        filter="objectClass=ast4ucsPhone",
-                        attribute=['asterisk/sipPhone: extension'],
-                        value='asterisk/sipPhone: dn',
-                ),
+			filter="objectClass=ast4ucsPhone",
+			attribute=['asterisk/sipPhone: extension'],
+			value='asterisk/sipPhone: dn',
+		),
 		multivalue=True,
 	),
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("commonName", "cn",
-	None, univention.admin.mapping.ListToString)
-mapping.register("id", "ast4ucsPhonegroupId",
-	None, univention.admin.mapping.ListToString)
+mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
+mapping.register("id", "ast4ucsPhonegroupId", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
@@ -109,32 +107,25 @@ class object(AsteriskBase):
 		reverseFieldsSave(self)
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhonegroup']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsPhonegroup']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsPhonegroup")
+		univention.admin.filter.expression('objectClass', "ast4ucsPhonegroup")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneType.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneType.py
@@ -61,46 +61,35 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("commonName", "cn",
-	None, univention.admin.mapping.ListToString)
-mapping.register("displaySize", "ast4ucsPhonetypeDisplaysize",
-	None, univention.admin.mapping.ListToString)
-mapping.register("manufacturer", "ast4ucsPhonetypeManufacturer",
-	None, univention.admin.mapping.ListToString)
-mapping.register("type", "ast4ucsPhonetypeType",
-	None, univention.admin.mapping.ListToString)
+mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
+mapping.register("displaySize", "ast4ucsPhonetypeDisplaysize", None, univention.admin.mapping.ListToString)
+mapping.register("manufacturer", "ast4ucsPhonetypeManufacturer", None, univention.admin.mapping.ListToString)
+mapping.register("type", "ast4ucsPhonetypeType", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhonetype']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsPhonetype']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsPhonetype")
+		univention.admin.filter.expression('objectClass', "ast4ucsPhonetype")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneType.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/phoneType.py
@@ -21,14 +21,21 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
-from univention.admin.handlers.asterisk import AsteriskBase
+from univention.admin.handlers import simpleLdap
 
 module = "asterisk/phoneType"
 short_description = u"Asterisk4UCS-Management: Telefontyp"
 operations = ['add', 'edit', 'remove', 'search', 'move']
 options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsPhonetype'],
+	),
+}
 
-childs = 0
+childs = False
 superordinate = "asterisk/server"
 
 layout = [
@@ -67,31 +74,18 @@ mapping.register("manufacturer", "ast4ucsPhonetypeManufacturer", None, univentio
 mapping.register("type", "ast4ucsPhonetypeType", None, univention.admin.mapping.ListToString)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhonetype']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsPhonetype")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsPhonetype' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/server.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/server.py
@@ -30,6 +30,13 @@ module = "asterisk/server"
 short_description = u"Asterisk4UCS-Management: Asterisk-Server"
 operations = ['add', 'edit', 'remove', 'search', 'move']
 options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsServer'],
+	),
+}
 
 childs = False
 
@@ -336,27 +343,7 @@ class object(univention.admin.handlers.simpleLdap):
 		number2name.setContent(open("/usr/lib/asterisk4ucs/number2name.agi").read())
 		number2name.create()
 
-	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsServer'])]
 
-
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsServer")
-	])
-	# logging.debug('server.py UDM 366: filter: %s', filter)
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	#logging.debug('server.py UDM 378: res: %s',res)
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsServer' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/server.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/server.py
@@ -56,6 +56,7 @@ childmodules = [
 class upstreamBug34040Exception(univention.admin.uexceptions.base):
 	message = u'Leider kann zur Zeit nicht mehr als ein Asterisk-Server angelegt werden, da <a href="http://forge.univention.org/bugzilla/show_bug.cgi?id=34040">ein Univention-Bug</a> dies verhindert.'
 
+
 layout = [
 	Tab('Allgemein', 'Allgemeine Einstellungen', layout=[
 		["commonName"],
@@ -158,17 +159,17 @@ property_descriptions = {
 	"mailboxEmailsubject": univention.admin.property(
 		short_description="Betreff der eMails",
 		long_description=u"""Die folgenden Platzhalter können verwendet werden:
-     ${VM_NAME}      Name des Mailbox-Inhabers
-     ${VM_DUR}       Länge der Nachricht
-     ${VM_MSGNUM}    Nummer der Nachricht
-     ${VM_MAILBOX}   Name der Mailbox
-     ${VM_CALLERID}  Telefonnummer und Name des Anrufers
-     ${VM_CIDNUM}    Telefonnummer des Anrufers
-     ${VM_CIDNAME}   Name des Anrufers
-     ${VM_DATE}      Datum und Uhrzeit des Anrufs
-     ${VM_MESSAGEFILE}
-		     Name der Sounddatei, in der die
-		     Nachricht abgespeichert ist""".replace("\n", "<br>"),
+	${VM_NAME}      Name des Mailbox-Inhabers
+	${VM_DUR}       Länge der Nachricht
+	${VM_MSGNUM}    Nummer der Nachricht
+	${VM_MAILBOX}   Name der Mailbox
+	${VM_CALLERID}  Telefonnummer und Name des Anrufers
+	${VM_CIDNUM}    Telefonnummer des Anrufers
+	${VM_CIDNAME}   Name des Anrufers
+	${VM_DATE}      Datum und Uhrzeit des Anrufs
+	${VM_MESSAGEFILE}
+			Name der Sounddatei, in der die
+			Nachricht abgespeichert ist""".replace("\n", "<br>").replace("\t", "    "),
 		syntax=univention.admin.syntax.string,
 		required=True,
 		default="New message from ${VM_CALLERID}",
@@ -176,25 +177,24 @@ property_descriptions = {
 	"mailboxEmailbody": univention.admin.property(
 		short_description="Textkörper der eMails",
 		long_description=u"""Die folgenden Platzhalter können verwendet werden:
-     ${VM_NAME}      Name des Mailbox-Inhabers
-     ${VM_DUR}       Länge der Nachricht
-     ${VM_MSGNUM}    Nummer der Nachricht
-     ${VM_MAILBOX}   Name der Mailbox
-     ${VM_CALLERID}  Telefonnummer und Name des Anrufers
-     ${VM_CIDNUM}    Telefonnummer des Anrufers
-     ${VM_CIDNAME}   Name des Anrufers
-     ${VM_DATE}      Datum und Uhrzeit des Anrufs
-     ${VM_MESSAGEFILE}
-		     Name der Sounddatei, in der die
-		     Nachricht abgespeichert ist
+	${VM_NAME}      Name des Mailbox-Inhabers
+	${VM_DUR}       Länge der Nachricht
+	${VM_MSGNUM}    Nummer der Nachricht
+	${VM_MAILBOX}   Name der Mailbox
+	${VM_CALLERID}  Telefonnummer und Name des Anrufers
+	${VM_CIDNUM}    Telefonnummer des Anrufers
+	${VM_CIDNAME}   Name des Anrufers
+	${VM_DATE}      Datum und Uhrzeit des Anrufs
+	${VM_MESSAGEFILE}
+			Name der Sounddatei, in der die
+			Nachricht abgespeichert ist
 
 Weiterhin können die folgenden Escapesequenzen verwendet werden:
-     \\n	     Neue Zeile
-     \\t	     Tabulator-Zeichen""".replace("\n", "<br>"),
+	\\n	     Neue Zeile
+	\\t	     Tabulator-Zeichen""".replace("\n", "<br>").replace("\t", "    "),
 		syntax=univention.admin.syntax.string,
 		required=True,
-		default="Hello ${VM_NAME},\n\nThere is a new message " + \
-			"in mailbox ${VM_MAILBOX}.",
+		default="Hello ${VM_NAME},\n\nThere is a new message in mailbox ${VM_MAILBOX}.",
 	),
 	"mailboxEmaildateformat": univention.admin.property(
 		short_description="Datumsformat in eMails",
@@ -232,8 +232,7 @@ Weiterhin können die folgenden Escapesequenzen verwendet werden:
 	),
 	"mailboxMailcommand": univention.admin.property(
 		short_description="Befehl zum Versenden der eMails",
-		long_description=u"Programm zum Versenden von E-Mails " + \
-			"(unbedingt den absoluten Pfad angeben!)",
+		long_description=u"Programm zum Versenden von E-Mails (unbedingt den absoluten Pfad angeben!)",
 		syntax=univention.admin.syntax.string,
 		required=True,
 		default="/usr/sbin/sendmail -t",
@@ -251,45 +250,28 @@ Weiterhin können die folgenden Escapesequenzen verwendet werden:
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("commonName", "cn",
-	None, univention.admin.mapping.ListToString)
+mapping.register("commonName", "cn", None, univention.admin.mapping.ListToString)
 mapping.register("blockedAreaCodes", "ast4ucsServerBlockedareacode")
 mapping.register("extnums", "ast4ucsServerExtnum")
-mapping.register("defaultext", "ast4ucsServerDefaultext",
-	None, univention.admin.mapping.ListToString)
+mapping.register("defaultext", "ast4ucsServerDefaultext", None, univention.admin.mapping.ListToString)
 
-mapping.register("sshuser", "ast4ucsServerSshuser",
-	None, univention.admin.mapping.ListToString)
-mapping.register("sshhost", "ast4ucsServerSshhost",
-	None, univention.admin.mapping.ListToString)
-mapping.register("sshpath", "ast4ucsServerSshpath",
-	None, univention.admin.mapping.ListToString)
-mapping.register("sshmohpath", "ast4ucsServerSshmohpath",
-	None, univention.admin.mapping.ListToString)
-mapping.register("sshagipath", "ast4ucsServerSshagipath",
-	None, univention.admin.mapping.ListToString)
-mapping.register("sshcmd", "ast4ucsServerSshcmd",
-	None, univention.admin.mapping.ListToString)
+mapping.register("sshuser", "ast4ucsServerSshuser", None, univention.admin.mapping.ListToString)
+mapping.register("sshhost", "ast4ucsServerSshhost", None, univention.admin.mapping.ListToString)
+mapping.register("sshpath", "ast4ucsServerSshpath", None, univention.admin.mapping.ListToString)
+mapping.register("sshmohpath", "ast4ucsServerSshmohpath", None, univention.admin.mapping.ListToString)
+mapping.register("sshagipath", "ast4ucsServerSshagipath", None, univention.admin.mapping.ListToString)
+mapping.register("sshcmd", "ast4ucsServerSshcmd", None, univention.admin.mapping.ListToString)
 
-mapping.register("mailboxMaxlength", "ast4ucsServerMailboxmaxlen",
-	None, univention.admin.mapping.ListToString)
-mapping.register("mailboxEmailsubject", "ast4ucsServerMailboxemailsubject",
-	None, univention.admin.mapping.ListToString)
-mapping.register("mailboxEmailbody", "ast4ucsServerMailboxemailbody",
-	None, univention.admin.mapping.ListToString)
-mapping.register("mailboxEmaildateformat", "ast4ucsServerMailboxemaildateformat",
-	None, univention.admin.mapping.ListToString)
-mapping.register("mailboxAttach", "ast4ucsServerMailboxattach",
-	None, univention.admin.mapping.ListToString)
-mapping.register("mailboxMailcommand", "ast4ucsServerMailboxemailcommand",
-	None, univention.admin.mapping.ListToString)
-mapping.register("globalCallId", "ast4ucsServerGlobalCallId",
-	None, univention.admin.mapping.ListToString)
+mapping.register("mailboxMaxlength", "ast4ucsServerMailboxmaxlen", None, univention.admin.mapping.ListToString)
+mapping.register("mailboxEmailsubject", "ast4ucsServerMailboxemailsubject", None, univention.admin.mapping.ListToString)
+mapping.register("mailboxEmailbody", "ast4ucsServerMailboxemailbody", None, univention.admin.mapping.ListToString)
+mapping.register("mailboxEmaildateformat", "ast4ucsServerMailboxemaildateformat", None, univention.admin.mapping.ListToString)
+mapping.register("mailboxAttach", "ast4ucsServerMailboxattach", None, univention.admin.mapping.ListToString)
+mapping.register("mailboxMailcommand", "ast4ucsServerMailboxemailcommand", None, univention.admin.mapping.ListToString)
+mapping.register("globalCallId", "ast4ucsServerGlobalCallId", None, univention.admin.mapping.ListToString)
 
-mapping.register("agi-user", "ast4ucsServerAgiuser",
-	None, univention.admin.mapping.ListToString)
-mapping.register("agi-password", "ast4ucsServerAgipassword",
-	None, univention.admin.mapping.ListToString)
+mapping.register("agi-user", "ast4ucsServerAgiuser", None, univention.admin.mapping.ListToString)
+mapping.register("agi-password", "ast4ucsServerAgipassword", None, univention.admin.mapping.ListToString)
 
 
 class object(univention.admin.handlers.simpleLdap):
@@ -299,7 +281,7 @@ class object(univention.admin.handlers.simpleLdap):
 		univention.admin.handlers.simpleLdap.open(self)
 
 		for areaCode in ["+", "00"]:
-			if not areaCode in self.info.get("blockedAreaCodes", []):
+			if areaCode not in self.info.get("blockedAreaCodes", []):
 				break
 		else:
 			self.info["blockInternational"] = "1"
@@ -358,24 +340,20 @@ class object(univention.admin.handlers.simpleLdap):
 		return [('objectClass', ['ast4ucsServer'])]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
 		univention.admin.filter.expression(
 			'objectClass', "ast4ucsServer")
 	])
- 	#logging.debug('server.py UDM 366: filter: %s', filter)
+	# logging.debug('server.py UDM 366: filter: %s', filter)
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	#logging.debug('server.py UDM 378: res: %s',res)
 	return res
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/sipPhone.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/sipPhone.py
@@ -66,10 +66,10 @@ property_descriptions = {
 	"phonetype": univention.admin.property(
 		short_description="Telefontyp",
 		syntax=univention.admin.syntax.LDAP_Search(
-                        filter="objectClass=ast4ucsPhonetype",
-                        attribute=['asterisk/phoneType: commonName'],
-                        value='asterisk/phoneType: dn'
-                ),
+			filter="objectClass=ast4ucsPhonetype",
+			attribute=['asterisk/phoneType: commonName'],
+			value='asterisk/phoneType: dn'
+		),
 	),
 	"profile": univention.admin.property(
 		short_description="Profil",
@@ -83,28 +83,28 @@ property_descriptions = {
 	"callgroups": univention.admin.property(
 		short_description="Callgroups",
 		syntax=univention.admin.syntax.LDAP_Search(
-                        filter="objectClass=ast4ucsPhonegroup",
-                        attribute=['asterisk/phoneGroup: commonName'],
-                        value='asterisk/phoneGroup: dn'
-                ),
+			filter="objectClass=ast4ucsPhonegroup",
+			attribute=['asterisk/phoneGroup: commonName'],
+			value='asterisk/phoneGroup: dn'
+		),
 		multivalue=True,
 	),
 	"pickupgroups": univention.admin.property(
 		short_description="Pickupgroups",
 		syntax=univention.admin.syntax.LDAP_Search(
-                        filter="objectClass=ast4ucsPhonegroup",
-                        attribute=['asterisk/phoneGroup: commonName'],
-                        value='asterisk/phoneGroup: dn'
-                ),
+			filter="objectClass=ast4ucsPhonegroup",
+			attribute=['asterisk/phoneGroup: commonName'],
+			value='asterisk/phoneGroup: dn'
+		),
 		multivalue=True,
 	),
 	"waitingloops": univention.admin.property(
 		short_description="Warteschleifen",
 		syntax=univention.admin.syntax.LDAP_Search(
-                        filter="objectClass=ast4ucsWaitingloop",
-                        attribute=['asterisk/waitingLoop: extension'],
-                        value='asterisk/waitingLoop: dn'
-                ),
+			filter="objectClass=ast4ucsWaitingloop",
+			attribute=['asterisk/waitingLoop: extension'],
+			value='asterisk/waitingLoop: dn'
+		),
 		multivalue=True,
 	),
 	"forwarding": univention.admin.property(
@@ -118,61 +118,44 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("extension", "ast4ucsExtensionExtension",
-	None, univention.admin.mapping.ListToString)
-
-mapping.register("ipaddress", "ast4ucsSipclientIp",
-	None, univention.admin.mapping.ListToString)
-mapping.register("macaddress", "ast4ucsSipclientMacaddr",
-	None, univention.admin.mapping.ListToString)
-mapping.register("hostname", "ast4ucsSipclientHostname",
-	None, univention.admin.mapping.ListToString)
-mapping.register("password", "ast4ucsSipclientSecret",
-	None, univention.admin.mapping.ListToString)
-
-mapping.register("phonetype", "ast4ucsPhonePhonetype",
-	None, univention.admin.mapping.ListToString)
-mapping.register("profile", "ast4ucsPhoneProfile",
-	None, univention.admin.mapping.ListToString)
+mapping.register("extension", "ast4ucsExtensionExtension", None, univention.admin.mapping.ListToString)
+mapping.register("ipaddress", "ast4ucsSipclientIp", None, univention.admin.mapping.ListToString)
+mapping.register("macaddress", "ast4ucsSipclientMacaddr", None, univention.admin.mapping.ListToString)
+mapping.register("hostname", "ast4ucsSipclientHostname", None, univention.admin.mapping.ListToString)
+mapping.register("password", "ast4ucsSipclientSecret", None, univention.admin.mapping.ListToString)
+mapping.register("phonetype", "ast4ucsPhonePhonetype", None, univention.admin.mapping.ListToString)
+mapping.register("profile", "ast4ucsPhoneProfile", None, univention.admin.mapping.ListToString)
 mapping.register("callgroups", "ast4ucsPhoneCallgroup")
 mapping.register("pickupgroups", "ast4ucsPhonePickupgroup")
 mapping.register("waitingloops", "ast4ucsPhoneWaitingloop")
-mapping.register("forwarding", "ast4ucsPhoneForwarding",
-	None, univention.admin.mapping.ListToString)
-mapping.register("skipExtension", "ast4ucsPhoneSkipextension",
-	None, univention.admin.mapping.ListToString)
+mapping.register("forwarding", "ast4ucsPhoneForwarding", None, univention.admin.mapping.ListToString)
+mapping.register("skipExtension", "ast4ucsPhoneSkipextension", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhone']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsPhone']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
 		univention.admin.filter.expression(
 			'objectClass', "ast4ucsPhone")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/sipPhone.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/sipPhone.py
@@ -21,14 +21,20 @@ import univention.admin.filter
 import univention.admin.handlers
 import univention.admin.syntax
 from univention.admin.layout import Tab
-from univention.admin.handlers.asterisk import AsteriskBase
+from univention.admin.handlers import simpleLdap
 
 module = "asterisk/sipPhone"
 short_description = u"Asterisk4UCS-Management: IP-Telefon"
 operations = ['add', 'edit', 'remove', 'search', 'move']
-options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsPhone'],
+	),
+}
 
-childs = 0
+childs = False
 superordinate = "asterisk/server"
 
 layout = [
@@ -132,32 +138,18 @@ mapping.register("forwarding", "ast4ucsPhoneForwarding", None, univention.admin.
 mapping.register("skipExtension", "ast4ucsPhoneSkipextension", None, univention.admin.mapping.ListToString)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsPhone']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsPhone")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsPhone' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/waitingLoop.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/waitingLoop.py
@@ -19,8 +19,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 import univention.admin.filter
 import univention.admin.handlers
-from univention.admin.handlers.asterisk import \
-	reverseFieldsLoad, reverseFieldsSave, AsteriskBase
+from univention.admin.handlers.asterisk import reverseFieldsLoad, reverseFieldsSave
+from univention.admin.handlers import simpleLdap
 import univention.admin.syntax
 from univention.admin.layout import Tab
 
@@ -28,6 +28,13 @@ module = "asterisk/waitingLoop"
 short_description = u"Asterisk4UCS-Management: Warteschlange"
 operations = ['add', 'edit', 'remove', 'search', 'move']
 options = {}
+options = {
+	'default': univention.admin.option(
+		short_description=short_description,
+		default=True,
+		objectClasses=['ast4ucsWaitingloop'],
+	),
+}
 
 childs = 0
 usewizard = 1
@@ -110,7 +117,7 @@ mapping.register("memberDelay", "ast4ucsWaitingloopMemberdelay", None, univentio
 mapping.register("delayMusic", "ast4ucsWaitingloopDelaymusic", None, univention.admin.mapping.ListToString)
 
 
-class object(AsteriskBase):
+class object(simpleLdap):
 	module = module
 
 	def __init__(self, co, lo, position, dn='', superordinate=None, attributes=None):
@@ -140,27 +147,14 @@ class object(AsteriskBase):
 		reverseFieldsSave(self)
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsWaitingloop']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('ast4ucsSrvchildServer', self.superordinate.dn)]
+
+	@classmethod
+	def lookup_filter_superordinate(cls, filter, superordinate):
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn, escape=True))
+		return filter
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
-	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression('objectClass', "ast4ucsWaitingloop")
-	])
-
-	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
-
-	if filter_s:
-		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
-		filter.expressions.append(filter_p)
-
-	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
-	return res
-
-
-def identify(dn, attr, canonical=0):
-	return 'ast4ucsWaitingloop' in attr.get('objectClass', [])
+lookup = object.lookup
+lookup_filter = object.lookup_filter
+identify = object.identify

--- a/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/waitingLoop.py
+++ b/asterisk4ucs-udm/modules/univention/admin/handlers/asterisk/waitingLoop.py
@@ -55,6 +55,7 @@ class SyntaxStrategy(univention.admin.syntax.select):
 		("random", u"Einen zufälligen Anschluss anklingeln"),
 	]
 
+
 property_descriptions = {
 	"extension": univention.admin.property(
 		short_description="Durchwahl",
@@ -83,8 +84,7 @@ property_descriptions = {
 	"delayMusic": univention.admin.property(
 		short_description="Warteschlangenmusik",
 		syntax=univention.admin.syntax.LDAP_Search(
-			filter="(&(objectClass=ast4ucsMusic)"
-				+ "(ast4ucsMusicMusic=*))",
+			filter="(&(objectClass=ast4ucsMusic)(ast4ucsMusicMusic=*))",
 			attribute=["asterisk/music: name"],
 			value="asterisk/music: name",
 		),
@@ -103,16 +103,11 @@ property_descriptions = {
 }
 
 mapping = univention.admin.mapping.mapping()
-mapping.register("extension", "ast4ucsExtensionExtension",
-	None, univention.admin.mapping.ListToString)
-mapping.register("strategy", "ast4ucsWaitingloopStrategy",
-	None, univention.admin.mapping.ListToString)
-mapping.register("maxCalls", "ast4ucsWaitingloopMaxcalls",
-	None, univention.admin.mapping.ListToString)
-mapping.register("memberDelay", "ast4ucsWaitingloopMemberdelay",
-	None, univention.admin.mapping.ListToString)
-mapping.register("delayMusic", "ast4ucsWaitingloopDelaymusic",
-	None, univention.admin.mapping.ListToString)
+mapping.register("extension", "ast4ucsExtensionExtension", None, univention.admin.mapping.ListToString)
+mapping.register("strategy", "ast4ucsWaitingloopStrategy", None, univention.admin.mapping.ListToString)
+mapping.register("maxCalls", "ast4ucsWaitingloopMaxcalls", None, univention.admin.mapping.ListToString)
+mapping.register("memberDelay", "ast4ucsWaitingloopMemberdelay", None, univention.admin.mapping.ListToString)
+mapping.register("delayMusic", "ast4ucsWaitingloopDelaymusic", None, univention.admin.mapping.ListToString)
 
 
 class object(AsteriskBase):
@@ -145,32 +140,25 @@ class object(AsteriskBase):
 		reverseFieldsSave(self)
 
 	def _ldap_addlist(self):
-		return [('objectClass', ['ast4ucsWaitingloop']),
-				('ast4ucsSrvchildServer', self.superordinate.dn)]
+		return [('objectClass', ['ast4ucsWaitingloop']), ('ast4ucsSrvchildServer', self.superordinate.dn)]
 
 
-def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub',
-		unique=False, required=False, timeout=-1, sizelimit=0):
+def lookup(co, lo, filter_s, base='', superordinate=None, scope='sub', unique=False, required=False, timeout=-1, sizelimit=0):
 	filter = univention.admin.filter.conjunction('&', [
-		univention.admin.filter.expression(
-			'objectClass', "ast4ucsWaitingloop")
+		univention.admin.filter.expression('objectClass', "ast4ucsWaitingloop")
 	])
 
 	if superordinate:
-		filter.expressions.append(univention.admin.filter.expression(
-				'ast4ucsSrvchildServer', superordinate.dn))
+		filter.expressions.append(univention.admin.filter.expression('ast4ucsSrvchildServer', superordinate.dn))
 
 	if filter_s:
 		filter_p = univention.admin.filter.parse(filter_s)
-		univention.admin.filter.walk(filter_p,
-			univention.admin.mapping.mapRewrite, arg=mapping)
+		univention.admin.filter.walk(filter_p, univention.admin.mapping.mapRewrite, arg=mapping)
 		filter.expressions.append(filter_p)
 
 	res = []
-	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique,
-			required, timeout, sizelimit):
-		res.append(object(co, lo, None, dn=dn,
-				superordinate=superordinate, attributes=attrs))
+	for dn, attrs in lo.search(unicode(filter), base, scope, [], unique, required, timeout, sizelimit):
+		res.append(object(co, lo, None, dn=dn, superordinate=superordinate, attributes=attrs))
 	return res
 
 

--- a/asterisk4ucs-udm/modules/univention/admin/hooks.d/asterisk.py
+++ b/asterisk4ucs-udm/modules/univention/admin/hooks.d/asterisk.py
@@ -54,29 +54,8 @@ class AsteriskUsersUserHook(simpleHook):
 			if mailboxUsers:
 				raise self.mailboxError(nameFromDn(mailboxdn), nameFromDn(mailboxUsers[0].dn))
 
-	def hook_open(self, module):
-		pass
-
 	def hook_ldap_pre_create(self, module):
 		self.checkFields(module)
 
 	def hook_ldap_pre_modify(self, module):
 		self.checkFields(module)
-
-	def hook_ldap_pre_remove(self, module):
-		pass
-
-	def hook_ldap_addlist(self, module, al=[]):
-		return al
-
-	def hook_ldap_modlist(self, module, ml=[]):
-		return ml
-
-	def hook_ldap_post_create(self, module):
-		pass
-
-	def hook_ldap_post_modify(self, module):
-		pass
-
-	def hook_ldap_post_remove(self, module):
-		pass

--- a/asterisk4ucs-udm/modules/univention/admin/hooks.d/asterisk.py
+++ b/asterisk4ucs-udm/modules/univention/admin/hooks.d/asterisk.py
@@ -44,25 +44,15 @@ class AsteriskUsersUserHook(simpleHook):
 		for phonedn in module.info.get("phones", []):
 			if not phonedn:
 				continue
-			phoneUsers = user.lookup(module.co, module.lo,
-				"(&(ast4ucsUserPhone=%s)(!(uid=%s)))" % (
-				escapeForLdapFilter(phonedn),
-				escapeForLdapFilter(module.info["username"])))
+			phoneUsers = user.lookup(module.co, module.lo, "(&(ast4ucsUserPhone=%s)(!(uid=%s)))" % (escapeForLdapFilter(phonedn), escapeForLdapFilter(module.info["username"])))
 			if phoneUsers:
-				raise self.phoneError(
-						nameFromDn(phonedn),
-						nameFromDn(phoneUsers[0].dn))
+				raise self.phoneError(nameFromDn(phonedn), nameFromDn(phoneUsers[0].dn))
 
 		mailboxdn = module.info.get("mailbox")
 		if mailboxdn:
-			mailboxUsers = user.lookup(module.co, module.lo,
-				"(&(ast4ucsUserMailbox=%s)(!(uid=%s)))" % (
-				escapeForLdapFilter(mailboxdn),
-				escapeForLdapFilter(module.info["username"])))
+			mailboxUsers = user.lookup(module.co, module.lo, "(&(ast4ucsUserMailbox=%s)(!(uid=%s)))" % (escapeForLdapFilter(mailboxdn), escapeForLdapFilter(module.info["username"])))
 			if mailboxUsers:
-				raise self.mailboxError(
-						nameFromDn(mailboxdn),
-						nameFromDn(mailboxUsers[0].dn))
+				raise self.mailboxError(nameFromDn(mailboxdn), nameFromDn(mailboxUsers[0].dn))
 
 	def hook_open(self, module):
 		pass

--- a/asterisk4ucs-udm/modules/univention/admin/syntax.d/asterisk.py
+++ b/asterisk4ucs-udm/modules/univention/admin/syntax.d/asterisk.py
@@ -1,4 +1,3 @@
-
 """
 Copyright (C) 2012 DECOIT GmbH <asterisk4ucs@decoit.de>
 
@@ -15,6 +14,10 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
+
+import re
+from univention.admin.syntax import select, integer, string
+import univention.admin.uexceptions
 
 
 class ast4ucsExtmodeSyntax(select):
@@ -35,7 +38,7 @@ class ast4ucsDurationSyntax(integer):
 		try:
 			number = int(text)
 			if number > 300 or number < 1:
-				raise ValueError
+				raise ValueError()
 		except ValueError:
 			raise univention.admin.uexceptions.valueError("Value must be a number between 1 and 120!")
 		return text

--- a/asterisk4ucs-udm/modules/univention/admin/syntax.d/asterisk.py
+++ b/asterisk4ucs-udm/modules/univention/admin/syntax.d/asterisk.py
@@ -37,8 +37,7 @@ class ast4ucsDurationSyntax(integer):
 			if number > 300 or number < 1:
 				raise ValueError
 		except ValueError:
-			raise univention.admin.uexceptions.valueError, \
-				"Value must be a number between 1 and 120!"
+			raise univention.admin.uexceptions.valueError("Value must be a number between 1 and 120!")
 		return text
 
 
@@ -48,10 +47,7 @@ class ast4ucsMusicNameSyntax(integer):
 	@classmethod
 	def parse(self, text):
 		if not bool(re.match(r"^[a-zA-Z0-9_-]+$", text)):
-			raise univention.admin.uexceptions.valueError, \
-				"Der Name einer Musikklasse darf nur " \
-					+ "Buchstaben, Zahlen und die " \
-					+ "Zeichen '-' und '_' enthalten."
+			raise univention.admin.uexceptions.valueError("Der Name einer Musikklasse darf nur Buchstaben, Zahlen und die Zeichen '-' und '_' enthalten.")
 		return text
 
 
@@ -61,8 +57,9 @@ class ast4ucsPhoneNumberSyntax(string):
 	@classmethod
 	def parse(self, text):
 		if not bool(re.match(r"^\+[0-9]{2,30}$", text)):
-			raise univention.admin.uexceptions.valueError, \
-				"Eine Telefonnummer muss im internationalen " \
-				+ "Format angegeben werden, z.B. " \
-				+ "+494215960640 anstatt 0421 596064-0"
+			raise univention.admin.uexceptions.valueError(
+				"Eine Telefonnummer muss im internationalen "
+				"Format angegeben werden, z.B. "
+				"+494215960640 anstatt 0421 596064-0"
+			)
 		return text

--- a/asterisk4ucs-udm/number2name.agi
+++ b/asterisk4ucs-udm/number2name.agi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -21,13 +21,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 import sys
 import ldap
 import logging
-import psycopg2
-import psycopg2.extras  # noqa: F401
 
 LOG_FILENAME = '/tmp/ast4ucs-number2name.log'
 
 # read options from config file
-config = open("/etc/asterisk4ucs.ldapconfig").read().split("\n")
+config = open("/etc/asterisk4ucs.ldapconfig").read().splitlines()
 LDAP_IP = config[0]
 LDAP_SEARCH_BASE = config[1]
 ADMIN_DN = config[2]
@@ -44,7 +42,7 @@ logging.basicConfig(
 )
 
 # Read and ignore AGI environment (read until blank line)
-env = dict()
+env = {}
 while len(sys.argv) < 2:
 	line = sys.stdin.readline().strip()
 	if not line:
@@ -92,25 +90,24 @@ if not result:
 	sys.exit(0)
 
 result = result[0][1]
-unwrap = lambda x: x[0] if x else None  # noqa: E731
 
-orga = unwrap(result.get('o'))
-last = unwrap(result.get('ast4ucsContactLastname'))
-first = unwrap(result.get('ast4ucsContactFirstname'))
+orga = result.get('o', [b''])[0].decode('UTF-8')
+last = result.get('ast4ucsContactLastname', [b''])[0].decode('UTF-8')
+first = result.get('ast4ucsContactFirstname', [b''])[0].decode('UTF-8')
 
 if first and last:
 	name = "%s %s" % (first, last)
 elif last:
 	name = last
 else:
-	name = first  # could be string or None
+	name = first
 
 if orga and name:
 	cn = "%s (%s)" % (name, orga)
 elif orga:
 	cn = orga
 else:
-	cn = name  # could be string or None
+	cn = name
 
 if not cn:
 	logging.info("Kontakt hat weder Name noch Organisation, exit")
@@ -135,7 +132,7 @@ for rule in rules:
 
 # Namen an Asterisk senden
 logging.info("Setze Variable CALLERID auf " + cname)
-#cname = unicode(cname, 'utf-8').encode('iso-8859-1')
+#cname = cname.encode('iso-8859-1')
 sys.stdout.write('SET CALLERID "%s"\n' % (cname))
 sys.stdout.flush()
 

--- a/asterisk4ucs-udm/number2name.agi
+++ b/asterisk4ucs-udm/number2name.agi
@@ -18,14 +18,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 
-import re
 import sys
-import time
 import ldap
-import random
 import logging
 import psycopg2
-import psycopg2.extras
+import psycopg2.extras  # noqa: F401
 
 LOG_FILENAME = '/tmp/ast4ucs-number2name.log'
 
@@ -77,24 +74,25 @@ elif search_num.startswith('0'):
 logging.info("Normalisierte Nummer: " + search_num)
 
 logging.debug("Verbinde mit LDAP-Server: " + LDAP_IP)
-l = ldap.initialize("ldap://" + LDAP_IP)
-l.simple_bind_s(ADMIN_DN, ADMIN_PW)
+lo = ldap.initialize("ldap://" + LDAP_IP)
+lo.simple_bind_s(ADMIN_DN, ADMIN_PW)
 
-query = ("(|"
-		"(ast4ucsContactFaxnumber=%s)"
-		"(telephoneNumber=%s)"
-		"(ast4ucsContactMobilenumber=%s)"
+query = (
+	"(|"
+	"(ast4ucsContactFaxnumber=%s)"
+	"(telephoneNumber=%s)"
+	"(ast4ucsContactMobilenumber=%s)"
 	")") % (search_num, search_num, search_num)
 logging.debug("Query: %s" % query)
 
-result = l.search_s(LDAP_SEARCH_BASE, ldap.SCOPE_SUBTREE, query)
+result = lo.search_s(LDAP_SEARCH_BASE, ldap.SCOPE_SUBTREE, query)
 
 if not result:
 	logging.info("Keinen Namen gefunden, exit")
 	sys.exit(0)
 
 result = result[0][1]
-unwrap = lambda x: x[0] if x else None
+unwrap = lambda x: x[0] if x else None  # noqa: E731
 
 orga = unwrap(result.get('o'))
 last = unwrap(result.get('ast4ucsContactLastname'))
@@ -122,7 +120,7 @@ cname = "%s <%s>" % (cn, env["agi_callerid"])
 
 # Sonderzeichen ersetzen
 rules = [
-#	(" ", "_"),
+	# (" ", "_"),
 	("ä", "ae"),
 	("ö", "oe"),
 	("ü", "ue"),

--- a/asterisk4ucs-udm/osgaImport.py
+++ b/asterisk4ucs-udm/osgaImport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # coding=utf-8
 
 """

--- a/asterisk4ucs-udm/osgaImport.py
+++ b/asterisk4ucs-udm/osgaImport.py
@@ -22,6 +22,7 @@ You should have received a copy of the GNU General Public License along
 with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
+from __future__ import print_function
 
 import sys
 
@@ -32,8 +33,8 @@ try:
 	pguser = sys.argv[4]
 	pgpass = sys.argv[5]
 except IndexError:
-	print "Usage:"
-	print "%s <phonebook DN> <host> <database> <user> <pass>" % sys.argv[0]
+	print("Usage:")
+	print("%s <phonebook DN> <host> <database> <user> <pass>" % sys.argv[0])
 	sys.exit(1)
 
 import re
@@ -43,19 +44,16 @@ import psycopg2.extras
 import univention.admin.uexceptions
 
 pb = PhoneBookWrapper(astpbdn)
-print "Deleting all contacts in phonebook %s, may take a while..." % (
-		pb.getName())
+print("Deleting all contacts in phonebook %s, may take a while..." % (pb.getName()))
 pb.empty()
-print "Done."
-print "Importing..."
+print("Done.")
+print("Importing...")
 
-conn = psycopg2.connect(host=pghost, database=pgdb,
-		user=pguser, password=pgpass)
+conn = psycopg2.connect(host=pghost, database=pgdb, user=pguser, password=pgpass)
 
 cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
-cur.execute("SELECT * FROM contacts "
-		"WHERE status != 'D' AND acc_read = 'group';")
+cur.execute("SELECT * FROM contacts WHERE status != 'D' AND acc_read = 'group';")
 contacts = cur.fetchall()
 
 
@@ -64,26 +62,26 @@ def formatNumber(number):
 		return None
 	return re.sub(r"[-/ ]", "", number)
 
+
 for contact in contacts:
-	sys.stdout.write("%s (%s)          \r" % (
-			contact["nachname"], contact["id"]))
+	sys.stdout.write("%s (%s)          \r" % (contact["nachname"], contact["id"]))
 	sys.stdout.flush()
 	try:
 		dn = pb.addContact(
 			firstname=contact["vorname"],
 			lastname=contact["nachname"],
 			organisation=contact["firma"],
-			phones=[formatNumber(contact["tel1"]),
-					formatNumber(contact["tel2"])],
+			phones=[
+				formatNumber(contact["tel1"]),
+				formatNumber(contact["tel2"])
+			],
 			mobiles=formatNumber(contact["mobil"]),
 			faxes=formatNumber(contact["fax"]),
 		)
-		#print "Created %s" % dn
+		#print("Created %s" % dn)
 	except univention.admin.uexceptions.valueInvalidSyntax:
-		print "Syntax error in contact %s (%s), skipping." % (
-				contact["nachname"], contact["id"])
+		print("Syntax error in contact %s (%s), skipping." % (contact["nachname"], contact["id"]))
 	except univention.admin.uexceptions.objectExists:
-		print "Found duplicate contact %s (%s), skipping." % (
-				contact["nachname"], contact["id"])
+		print("Found duplicate contact %s (%s), skipping." % (contact["nachname"], contact["id"]))
 
-print "Done.          "
+print("Done.          ")

--- a/asterisk4ucs-umc-deploy/debian/asterisk4ucs-umc-deploy.postinst
+++ b/asterisk4ucs-umc-deploy/debian/asterisk4ucs-umc-deploy.postinst
@@ -2,7 +2,7 @@
 
 #DEBHELPER#
 
-PID=$(echo `pgrep -f '^/usr/bin/python /usr/sbin/univention-management-console-module.* -m asteriskDeploy' || true`)
+PID=$(echo `pgrep -f '^/usr/bin/python3 /usr/sbin/univention-management-console-module.* -m asteriskDeploy' || true`)
 if [ -n "$PID" ]; then
 	echo "Killing old module process(es): $PID"
 	kill $PID

--- a/asterisk4ucs-umc-deploy/debian/changelog
+++ b/asterisk4ucs-umc-deploy/debian/changelog
@@ -1,3 +1,9 @@
+asterisk4ucs-umc-deploy (2.0.1) unstable; urgency=medium
+
+  * Add UCS 5.0 support. Migrate to Python 3
+
+ -- Florian Best <best@univention.de>  Sun, 03 Apr 2022 20:53:55 +0200
+
 asterisk4ucs-umc-deploy (1.0.1) unstable; urgency=low
 
   * Bugfix für 'FileNotFound'-Fehler

--- a/asterisk4ucs-umc-deploy/debian/control
+++ b/asterisk4ucs-umc-deploy/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Tristan Bruns (Decoit GmbH) <bruns@decoit.de>
 Build-Depends: debhelper (>= 7.0.50~),
  univention-management-console-dev,
- python-univention
+ python3-univention
 Standards-Version: 3.5.2
 XS-Python-Version: all
 

--- a/asterisk4ucs-umc-deploy/umc/asteriskDeploy.xml
+++ b/asterisk4ucs-umc-deploy/umc/asteriskDeploy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <umc version="2.0">
-	<module id="asteriskDeploy" icon="asteriskDeploy" version="1.0">
+	<module id="asteriskDeploy" icon="asteriskDeploy" python="3" version="1.0">
 		<name>Asterisk4UCS Deployment</name>
 		<description>Deploys Asterisk4UCS configuration files</description>
 		<categories>

--- a/asterisk4ucs-umc-deploy/umc/python/asteriskDeploy/__init__.py
+++ b/asterisk4ucs-umc-deploy/umc/python/asteriskDeploy/__init__.py
@@ -220,15 +220,13 @@ def deployConfigs(log, server, configs):
 		f.close()
 
 		for name, data in configs.items():
-			f = open("%s/%s" % (tmpdirConfig, name), "w")
-			f.write(data)
-			f.close()
+			with open("%s/%s" % (tmpdirConfig, name), "w") as fd:
+				fd.write(data)
 
 		for name, data in agis.items():
-			f = open("%s/%s" % (tmpdirAgi, name), "w")
-			f.write(data)
-			os.fchmod(f.fileno(), 0o755)
-			f.close()
+			with open("%s/%s" % (tmpdirAgi, name), "w") as fd:
+				fd.write(data)
+				os.fchmod(fd.fileno(), 0o755)
 
 		logCall(log, ["scp", "-Bq", tmpfileLdapconf, scptargetLdapconf], tmpdirConfig)
 		logCall(log, ["scp", "-Bq"] + configs.keys() + [scptargetConfig], tmpdirConfig)

--- a/asterisk4ucs-umc-music/debian/asterisk4ucs-umc-music.postinst
+++ b/asterisk4ucs-umc-music/debian/asterisk4ucs-umc-music.postinst
@@ -2,7 +2,7 @@
 
 #DEBHELPER#
 
-PID=$(echo `pgrep -f '^/usr/bin/python /usr/sbin/univention-management-console-module.* -m asteriskMusic' || true`)
+PID=$(echo `pgrep -f '^/usr/bin/python3 /usr/sbin/univention-management-console-module.* -m asteriskMusic' || true`)
 if [ -n "$PID" ]; then
 	echo "Killing old module process(es): $PID"
 	kill $PID

--- a/asterisk4ucs-umc-music/debian/changelog
+++ b/asterisk4ucs-umc-music/debian/changelog
@@ -1,3 +1,9 @@
+asterisk4ucs-umc-music (2.0.1) unstable; urgency=medium
+
+  * Add UCS 5.0 support. Migrate to Python 3
+
+ -- Florian Best <best@univention.de>  Sun, 03 Apr 2022 20:51:11 +0200
+
 asterisk4ucs-umc-music (1.0.0) unstable; urgency=low
 
   * Einige Bugfixes, Vorbereitung auf Release

--- a/asterisk4ucs-umc-music/debian/control
+++ b/asterisk4ucs-umc-music/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Tristan Bruns (Decoit GmbH) <bruns@decoit.de>
 Build-Depends: debhelper (>= 7.0.50~),
  univention-management-console-dev,
- python-univention
+ python3-univention
 Standards-Version: 3.5.2
 XS-Python-Version: all
 

--- a/asterisk4ucs-umc-music/umc/asteriskMusic.xml
+++ b/asterisk4ucs-umc-music/umc/asteriskMusic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <umc version="2.0">
-	<module id="asteriskMusic" icon="asteriskMusic" version="1.0">
+	<module id="asteriskMusic" icon="asteriskMusic" python="3">
 		<name>Asterisk4UCS Warteschlangenmusiken</name>
 		<description>Musikupload für Asterisk4UCS-Warteschlangen</description>
 		<categories>

--- a/asterisk4ucs-umc-music/umc/python/asteriskMusic/__init__.py
+++ b/asterisk4ucs-umc-music/umc/python/asteriskMusic/__init__.py
@@ -36,13 +36,16 @@ import logging
 logfile = "/var/log/univention/asteriskMusicPython.log"
 logFilename = "/var/log/univention/asteriskMusicUpload.log"
 
+
 class Instance(Base):
-	logging.basicConfig(filename=logfile,
+	logging.basicConfig(
+		filename=logfile,
 		#level=logging.INFO,
 		level=logging.DEBUG,
-		format = "%(asctime)s\t%(levelname)s\t%(message)s",
-		datefmt = "%d.%m.%Y %H:%M:%S"
-		)
+		format="%(asctime)s\t%(levelname)s\t%(message)s",
+		datefmt="%d.%m.%Y %H:%M:%S"
+	)
+
 	def queryServers(self, request):
 		servers = getServers()
 		result = []
@@ -91,7 +94,7 @@ class Instance(Base):
 	def create(self, request):
 		server = request.options['server']
 		name = request.options["name"]
-		logging.debug('__init__.py: server: %s , %s',request.options['server'],name)
+		logging.debug('__init__.py: server: %s , %s', request.options['server'], name)
 		result = {
 			"newDn": create(server, name),
 		}
@@ -99,7 +102,7 @@ class Instance(Base):
 		self.finished(request.id, result)
 
 	def delete(self, request):
-		logging.debug('__init__.py: moh: %s' , request)
+		logging.debug('__init__.py: moh: %s', request)
 		moh = getMoh(request.options["mohdn"])
 		delete(moh)
 		moh.remove()
@@ -107,7 +110,7 @@ class Instance(Base):
 		self.finished(request.id, True)
 
 	def upload(self, request):
-		logging.debug('__init__.py: Upload requestMoh: %s',request.options["moh"])
+		logging.debug('__init__.py: Upload requestMoh: %s', request.options["moh"])
 		moh = getMoh(request.options["moh"])
 		logging.debug('__init__.py: getMoh: %s', moh)
 		server = getServer(re.sub(r"^[^,]+,", "", request.options["moh"]))
@@ -121,25 +124,26 @@ class Instance(Base):
 		stem = re.sub(r"^_+", "", stem)
 		stem = re.sub(r"_+$", "", stem)
 		logging.debug('__init__.py: stem: %s', stem)
-		logging.debug('__init__.py: moh.info.get: %s',moh.info.get("music"));
+		logging.debug('__init__.py: moh.info.get: %s', moh.info.get("music"))
 
 		if stem in moh.info.get("music", []):
-			logging.debug('__init__.py: moh.info.get: %s',moh.info.get("music"));
+			logging.debug('__init__.py: moh.info.get: %s', moh.info.get("music"))
 			self.finished(request.id, {
 				"success": False,
 				"details": "Ein Musikstueck mit diesem Namen wurde bereits hochgeladen!",
 			})
-			logging.debug('__init__.py: vor return');
+			logging.debug('__init__.py: vor return')
 			return
 
 		#logging.debug('__init__.py: Upload Server: %s, MOH: %s, stem: %s, filename: %s',server,moh,stem,filenane)
 		if uploadMusic(server, moh, data, stem, filename):
 			moh.info.setdefault("music", []).append(stem)
 			moh.modify()
-			self.finished(request.id, {"foo":"bar"})
+			self.finished(request.id, {"foo": "bar"})
 		else:
 			log = open(logFilename).read()
 			self.finished(request.id, {"error": log})
+
 
 def getCoLoPos():
 	co = None
@@ -148,6 +152,7 @@ def getCoLoPos():
 	#logging.debug('__init__.py: lo: %s pos: %s',lo, pos)
 
 	return co, lo, pos
+
 
 def getServers():
 	co, lo, pos = getCoLoPos()
@@ -161,6 +166,7 @@ def getServers():
 
 	return servers
 
+
 def getMohs():
 	co, lo, pos = getCoLoPos()
 
@@ -173,16 +179,18 @@ def getMohs():
 
 	return mohs
 
+
 def getMoh(dn):
 	co, lo, pos = getCoLoPos()
 
 	music = univention.admin.modules.get("asterisk/music")
 	univention.admin.modules.init(lo, pos, music)
-	
+
 	moh = music.object(co, lo, None, dn)
 	moh.open()
 
 	return moh
+
 
 def getServer(dn):
 	co, lo, pos = getCoLoPos()
@@ -194,6 +202,7 @@ def getServer(dn):
 
 	return obj
 
+
 def create(serverdn, name):
 	co, lo, pos = getCoLoPos()
 
@@ -202,7 +211,7 @@ def create(serverdn, name):
 	srv = server.object(co, lo, pos, serverdn)
 	srv.open()
 	if not srv.exists():
-		raise Exception, "Invalid serverDN"
+		raise Exception("Invalid serverDN")
 
 	pos.setDn(serverdn)
 
@@ -214,6 +223,7 @@ def create(serverdn, name):
 	moh.create()
 
 	return moh.dn
+
 
 def uploadMusic(server, moh, data, stem, filename):
 	log = open(logFilename, "w", 0)
@@ -227,18 +237,16 @@ def uploadMusic(server, moh, data, stem, filename):
 	tmpdir = tempfile.mkdtemp()
 	try:
 		inputfilename = "input_file"
-		logging.debug('__init__.py: filename: %s',filename);
-		logging.debug('__init__.py: inputfilename: %s',inputfilename);
-		if re.search("\.mp3$", filename):
+		logging.debug('__init__.py: filename: %s', filename)
+		logging.debug('__init__.py: inputfilename: %s', inputfilename)
+		if re.search(r"\.mp3$", filename):
 			inputfilename += ".mp3"
 
 		inputfile = open("%s/%s" % (tmpdir, inputfilename), "wb")
 		inputfile.write(data)
 		inputfile.close()
 
-		subprocess.check_call([scriptpath, stem, inputfilename,
-				mohname, sshtarget, sshmohpath, sshcmd],
-				stdout=log, stderr=log, cwd=tmpdir)
+		subprocess.check_call([scriptpath, stem, inputfilename, mohname, sshtarget, sshmohpath, sshcmd], stdout=log, stderr=log, cwd=tmpdir)
 	except subprocess.CalledProcessError:
 		return False
 	finally:
@@ -246,8 +254,10 @@ def uploadMusic(server, moh, data, stem, filename):
 
 	return True
 
+
 def escaped_command_string(x):
 	return ' '.join(map(pipes.quote, x))
+
 
 def delete(moh):
 	server = moh.superordinate
@@ -260,8 +270,9 @@ def delete(moh):
 	mohpath = "%s/%s" % (sshmohpath, mohname)
 	remotecmd = ';'.join([escaped_command_string(['rm', '-r', mohpath]), escaped_command_string([sshcmd, '-rx', 'moh reload'])])
 
-	subprocess.check_call(["ssh", "-oBatchMode=yes", sshtarget, remotecmd],
-			stdout=log, stderr=log)
+	subprocess.check_call(["ssh", "-oBatchMode=yes", sshtarget, remotecmd], stdout=log, stderr=log)
+
+
 def deleteSong(moh, song):
 	server = moh.superordinate
 	log = open(logFilename, "w", 0)
@@ -272,10 +283,6 @@ def deleteSong(moh, song):
 	sshmohpath = server.info.get("sshmohpath", "/opt/asterisk4ucs/moh")
 	mohpath = "%s/%s/%s" % (sshmohpath, mohname, song)
 	bashcmd = "rm %s.*" % pipes.quote(mohpath)
-	remotecmd = "bash -c %s; %s -rx 'moh reload'" % (
-			pipes.quote(bashcmd),
-			pipes.quote(sshcmd))
+	remotecmd = "bash -c %s; %s -rx 'moh reload'" % (pipes.quote(bashcmd), pipes.quote(sshcmd))
 
-	subprocess.check_call(["ssh", "-oBatchMode=yes", sshtarget, remotecmd],
-			stdout=log, stderr=log)
-
+	subprocess.check_call(["ssh", "-oBatchMode=yes", sshtarget, remotecmd], stdout=log, stderr=log)

--- a/asterisk4ucs-umc-music/umc/python/asteriskMusic/__init__.py
+++ b/asterisk4ucs-umc-music/umc/python/asteriskMusic/__init__.py
@@ -15,12 +15,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
 
 from univention.management.console.base import Base
-from univention.management.console.log import MODULE
 
 import univention.admin.uldap
 
 import univention.admin.modules
-univention.admin.modules.update()
 
 import univention.admin.handlers.asterisk.server
 import univention.admin.handlers.asterisk.music
@@ -32,6 +30,8 @@ import shutil
 import tempfile
 import subprocess
 import logging
+
+univention.admin.modules.update()
 
 logfile = "/var/log/univention/asteriskMusicPython.log"
 logFilename = "/var/log/univention/asteriskMusicUpload.log"
@@ -256,7 +256,7 @@ def uploadMusic(server, moh, data, stem, filename):
 
 
 def escaped_command_string(x):
-	return ' '.join(map(pipes.quote, x))
+	return ' '.join(pipes.quote(s) for s in x)
 
 
 def delete(moh):

--- a/asterisk4ucs-umc-user/debian/asterisk4ucs-umc-user.postinst
+++ b/asterisk4ucs-umc-user/debian/asterisk4ucs-umc-user.postinst
@@ -2,7 +2,7 @@
 
 #DEBHELPER#
 
-PID=$(echo `pgrep -f '^/usr/bin/python /usr/sbin/univention-management-console-module.* -m asteriskUser' || true`)
+PID=$(echo `pgrep -f '^/usr/bin/python3 /usr/sbin/univention-management-console-module.* -m asteriskUser' || true`)
 if [ -n "$PID" ]; then
 	echo "Killing old module process(es): $PID"
 	kill $PID

--- a/asterisk4ucs-umc-user/debian/changelog
+++ b/asterisk4ucs-umc-user/debian/changelog
@@ -1,3 +1,9 @@
+asterisk4ucs-umc-user (2.0.1) unstable; urgency=medium
+
+  * Add UCS 5.0 support. Migrate to Python 3
+
+ -- Florian Best <best@univention.de>  Sun, 03 Apr 2022 20:52:20 +0200
+
 asterisk4ucs-umc-user (1.0.0) unstable; urgency=low
 
   * Einige Bugfixes, Vorbereitung auf Release

--- a/asterisk4ucs-umc-user/debian/control
+++ b/asterisk4ucs-umc-user/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Tristan Bruns (Decoit GmbH) <bruns@decoit.de>
 Build-Depends: debhelper (>= 7.0.50~),
  univention-management-console-dev,
- python-univention
+ python3-univention
 Standards-Version: 3.5.2
 XS-Python-Version: all
 

--- a/asterisk4ucs-umc-user/umc/asteriskUser.xml
+++ b/asterisk4ucs-umc-user/umc/asteriskUser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <umc version="2.0">
-	<module id="asteriskUser" icon="asteriskUser" version="1.0">
+	<module id="asteriskUser" icon="asteriskUser" python="3" version="1.0">
 		<name>Asterisk4UCS Telefoneinstellungen</name>
 		<description>Asterisk4UCS Telefoneinstellungen</description>
 		<categories>

--- a/asterisk4ucs-umc-user/umc/python/asteriskUser/__init__.py
+++ b/asterisk4ucs-umc-user/umc/python/asteriskUser/__init__.py
@@ -28,14 +28,15 @@ import univention.admin.handlers.asterisk.sipPhone
 import univention.admin.handlers.asterisk.mailbox
 import univention.admin.handlers.asterisk.server
 
+
 class Instance(Base):
 
-	def load( self, request ):
+	def load(self, request):
 		user, mailbox = getUserAndMailbox(self._user_dn)
 		raise UMC_Error("Es wurde kein Asterisk-Server angelegt!")
 		result = {
 			"phones/interval": user["ringdelay"],
-			"forwarding/number": user.get("forwarding",""),
+			"forwarding/number": user.get("forwarding", ""),
 
 			"mailbox/timeout": user["timeout"],
 			"mailbox": False,
@@ -48,16 +49,15 @@ class Instance(Base):
 				"mailbox/email": mailbox["email"],
 			})
 
-		self.finished( request.id, result )
+		self.finished(request.id, result)
 
-	def save( self, request ):
+	def save(self, request):
 		user, mailbox = getUserAndMailbox(self._user_dn)
 
 		user["ringdelay"] = request.options["phones/interval"]
 		user["timeout"] = request.options["mailbox/timeout"]
 		if request.options["forwarding/number"]:
-			user["forwarding"] = request.options[
-					"forwarding/number"]
+			user["forwarding"] = request.options["forwarding/number"]
 		else:
 			try:
 				del user.info["forwarding"]
@@ -70,21 +70,16 @@ class Instance(Base):
 			mailbox["email"] = request.options["mailbox/email"]
 			mailbox.modify()
 
-		self.finished( request.id, None, "Speichern war erfolgreich!" )
+		self.finished(request.id, None, "Speichern war erfolgreich!")
 
 	def phonesQuery(self, request):
-		if (request.options.get("dn") and
-				request.options.get("position")
-					in ["-1", "1"]):
-			changePhoneOrder(
-					self._user_dn,
-					request.options["dn"],
-					int(request.options["position"]))
+		if (request.options.get("dn") and request.options.get("position") in ["-1", "1"]):
+			changePhoneOrder(self._user_dn, request.options["dn"], int(request.options["position"]))
 
 		phones = getPhones(self._user_dn)
 
 		result = []
-		for i,phone in enumerate(phones):
+		for i, phone in enumerate(phones):
 			result.append({
 				"position": i,
 				"dn": phone.dn,
@@ -93,33 +88,34 @@ class Instance(Base):
 
 		self.finished(request.id, result)
 
+
 def getCoLo():
 	lo = univention.admin.uldap.getAdminConnection()[0]
 	co = None
 	return co, lo
 
+
 def getUser(co, lo, dn):
 	position = univention.admin.uldap.position(lo.base)
 
-	univention.admin.modules.init(lo, position,
-		univention.admin.handlers.users.user)
+	univention.admin.modules.init(lo, position, univention.admin.handlers.users.user)
 
-	obj = univention.admin.handlers.users.user.object(co, lo,
-		None, dn)
+	obj = univention.admin.handlers.users.user.object(co, lo, None, dn)
 	obj.open()
 	return obj
+
 
 def getPhone(co, lo, dn):
-	obj = univention.admin.handlers.asterisk.sipPhone.object(co, lo,
-		None, dn)
+	obj = univention.admin.handlers.asterisk.sipPhone.object(co, lo, None, dn)
 	obj.open()
 	return obj
 
+
 def getMailbox(co, lo, dn):
-	obj = univention.admin.handlers.asterisk.mailbox.object(co, lo,
-		None, dn)
+	obj = univention.admin.handlers.asterisk.mailbox.object(co, lo, None, dn)
 	obj.open()
 	return obj
+
 
 def getPhones(userdn):
 	co, lo = getCoLo()
@@ -132,6 +128,7 @@ def getPhones(userdn):
 
 	return phones
 
+
 def getUserAndMailbox(userdn):
 	co, lo, pos = getCoLoPos()
 
@@ -141,12 +138,12 @@ def getUserAndMailbox(userdn):
 
 	checkServers = []
 	for obj in objs:
-			checkServers.append({
-				"label": obj["commonName"],
-			})
+		checkServers.append({
+			"label": obj["commonName"],
+		})
 
 	MODULE.error('User: server: %s' % len(checkServers))
-	if len(checkServers) >0 :
+	if len(checkServers) > 0:
 		co, lo = getCoLo()
 
 		user = getUser(co, lo, userdn)
@@ -156,7 +153,7 @@ def getUserAndMailbox(userdn):
 			mailbox = getMailbox(co, lo, mailbox)
 
 		return user, mailbox
-	elif len(checkServers) == 0 :
+	elif len(checkServers) == 0:
 		MODULE.error('Fehler gefunden!')
 		mailbox = "KeinServer"
 		user = "KeinServer"
@@ -168,6 +165,7 @@ def getCoLoPos():
 	lo, pos = univention.admin.uldap.getAdminConnection()
 	return co, lo, pos
 
+
 def changePhoneOrder(userdn, phonedn, change):
 	co, lo = getCoLo()
 
@@ -177,9 +175,9 @@ def changePhoneOrder(userdn, phonedn, change):
 	i = phones.index(phonedn)
 	phones.pop(i)
 	if change == -1 and i > 0:
-		phones.insert(i-1, phonedn)
+		phones.insert(i - 1, phonedn)
 	elif change == 1:
-		phones.insert(i+1, phonedn)
+		phones.insert(i + 1, phonedn)
 
 	user["phones"] = phones
 	user.modify()

--- a/asterisk4ucs-umc-user/umc/python/asteriskUser/__init__.py
+++ b/asterisk4ucs-umc-user/umc/python/asteriskUser/__init__.py
@@ -21,12 +21,13 @@ from univention.management.console.log import MODULE
 import univention.config_registry
 import univention.admin.uldap
 import univention.admin.modules
-univention.admin.modules.update()
 
 import univention.admin.handlers.users.user
 import univention.admin.handlers.asterisk.sipPhone
 import univention.admin.handlers.asterisk.mailbox
 import univention.admin.handlers.asterisk.server
+
+univention.admin.modules.update()
 
 
 class Instance(Base):
@@ -143,7 +144,7 @@ def getUserAndMailbox(userdn):
 		})
 
 	MODULE.error('User: server: %s' % len(checkServers))
-	if len(checkServers) > 0:
+	if checkServers:
 		co, lo = getCoLo()
 
 		user = getUser(co, lo, userdn)
@@ -153,7 +154,7 @@ def getUserAndMailbox(userdn):
 			mailbox = getMailbox(co, lo, mailbox)
 
 		return user, mailbox
-	elif len(checkServers) == 0:
+	else:
 		MODULE.error('Fehler gefunden!')
 		mailbox = "KeinServer"
 		user = "KeinServer"


### PR DESCRIPTION
Migrate the modules so they work with Python 3 and UCS 5.0.
The project reached EOL, so you could just merge it for those still using this tool unofficial.